### PR TITLE
Subtask changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,8 @@ THE SOFTWARE.
             <version>${workflow-api.version}</version>
             <scope>test</scope>
         </dependency>
+
+
         <!-- RequireUpperBounds fix -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -269,7 +271,9 @@ THE SOFTWARE.
             <artifactId>kotlin-stdlib</artifactId>
             <version>1.3.71</version>
         </dependency>
+
     </dependencies>
+
     <!-- The current maintainers of the plugin -->
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 The MIT License (MIT)
-
 Copyright (c) 2016- Eficode Ltd
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,39 +20,33 @@ THE SOFTWARE.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>3.50</version>
     </parent>
-
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
-
     <name>InfluxDB Plugin</name>
     <description>Plugin for pushing time series data to InfluxDB, inspired by https://github.com/jrajala-eficode/jenkins-ci.influxdb-plugin and http://christoph-burmeister.eu/?p=2906</description>
-
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
         <tag>HEAD</tag>
     </scm>
-
     <properties>
         <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
         <java.level>8</java.level>
-        <jenkins.version>2.195</jenkins.version>
+        <jenkins.version>2.222.1</jenkins.version>
         <mailer.version>1.20</mailer.version>
         <slf4j.version>1.7.30</slf4j.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
         <workflow-api.version>2.30</workflow-api.version>
         <workflow-step-api.version>2.19</workflow-step-api.version>
     </properties>
-
     <licenses>
         <license>
             <name>MIT license</name>
@@ -64,7 +54,6 @@ THE SOFTWARE.
             <comments>All source code is under the MIT license.</comments>
         </license>
     </licenses>
-
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -77,18 +66,17 @@ THE SOFTWARE.
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>structs</artifactId>
-                <version>1.17</version>
+                <version>1.18</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci</groupId>
                 <artifactId>symbol-annotation</artifactId>
-                <version>1.10</version>
+                <version>1.18</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
@@ -135,9 +123,14 @@ THE SOFTWARE.
                 <artifactId>byte-buddy-agent</artifactId>
                 <version>1.9.10</version>
             </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-durable-task-step</artifactId>
+                <version>2.35</version>
+                <optional>true</optional>
+            </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>com.influxdb</groupId>
@@ -167,7 +160,6 @@ THE SOFTWARE.
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>
         </dependency>
-
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cobertura</artifactId>
@@ -199,13 +191,13 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>metrics</artifactId>
-            <version>3.1.2.9</version>
+            <version>4.0.2.10-SNAPSHOT</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>performance</artifactId>
-            <version>3.0</version>
+            <version>3.5</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -231,8 +223,6 @@ THE SOFTWARE.
             <version>${workflow-api.version}</version>
             <scope>test</scope>
         </dependency>
-
-
         <!-- RequireUpperBounds fix -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -269,9 +259,7 @@ THE SOFTWARE.
             <artifactId>kotlin-stdlib</artifactId>
             <version>1.3.71</version>
         </dependency>
-
     </dependencies>
-
     <!-- The current maintainers of the plugin -->
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 The MIT License (MIT)
+
 Copyright (c) 2016- Eficode Ltd
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
+
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/pom.xml
+++ b/pom.xml
@@ -20,23 +20,28 @@ THE SOFTWARE.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>3.50</version>
     </parent>
+
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.0.2.1-SNAPSHOT</version>
+    <version>3.0.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
+
     <name>InfluxDB Plugin</name>
     <description>Plugin for pushing time series data to InfluxDB, inspired by https://github.com/jrajala-eficode/jenkins-ci.influxdb-plugin and http://christoph-burmeister.eu/?p=2906</description>
+
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
         <tag>HEAD</tag>
     </scm>
+
     <properties>
         <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
         <java.level>8</java.level>
@@ -47,6 +52,7 @@ THE SOFTWARE.
         <workflow-api.version>2.30</workflow-api.version>
         <workflow-step-api.version>2.19</workflow-step-api.version>
     </properties>
+
     <licenses>
         <license>
             <name>MIT license</name>
@@ -54,6 +60,7 @@ THE SOFTWARE.
             <comments>All source code is under the MIT license.</comments>
         </license>
     </licenses>
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -66,6 +73,7 @@ THE SOFTWARE.
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -131,6 +139,7 @@ THE SOFTWARE.
             </dependency>
         </dependencies>
     </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.influxdb</groupId>
@@ -160,6 +169,7 @@ THE SOFTWARE.
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>
         </dependency>
+
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cobertura</artifactId>

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -14,6 +14,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
 public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
     public static final String BUILD_TIME = "build_time";
@@ -44,6 +47,11 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     public static final String TESTS_FAILED = "tests_failed";
     public static final String TESTS_SKIPPED = "tests_skipped";
     public static final String TESTS_TOTAL = "tests_total";
+
+    public static final String TOTAL_TIME_IN_QUEUE = "total_time_in_queue";
+    public static final String NUM_SUBTASKS = "num_subtasks";
+
+    public static final Integer MAX_SUBTASKS = 50;
 
     private final Run<?, ?> build;
     private final String customPrefix;
@@ -112,7 +120,25 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
         }
 
         if (hasMetricsPlugin(build)) {
+            java.util.logging.Logger LOGGER = java.util.logging.Logger.getLogger(this.getClass().getName());
+
             point.addField(TIME_IN_QUEUE, build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getQueuingDurationMillis());
+            point.addField(TOTAL_TIME_IN_QUEUE, build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getQueuingTimeMillis());
+            point.addField(NUM_SUBTASKS, build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getSubTaskCount());
+
+            // Subtask Point Generator -- Used to check longest subtask wait time
+            int subtask_count = 0;
+            for (Map.Entry<String, Long> subtask :
+                build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getSubTaskMap().entrySet()) {
+
+                if (subtask_count > MAX_SUBTASKS) {
+                    LOGGER.log(Level.WARNING, "Too many subtasks");
+                    break;
+                }
+
+                point.addField(subtask.getKey(), subtask.getValue());
+                subtask_count++;
+            }
         }
 
         if (StringUtils.isNotBlank(jenkinsEnvParameterField)) {


### PR DESCRIPTION
Goal: Take data from metrics using InfluxDB to upload newly implemented queries onto _grafana_, our visual interface for our data. Newly added data categories include: subtask time in queue data, summed time in queue, and total number of subtasks. With the subtask time in queue data, one can find the subtask that waited longest in queue, which could be useful.

Within the file **JenkinsBasePointGenerator.java**, there is a section that allows for statistics to be pulled from metrics for InfluxDB to use and upload onto the grafana visual interface. 

A _Point_ object is representative of one data point that is visually shown in grafana. Each of these points can have _fields_, which are categories in which grafana can be used to query for. 

My first two changes were adding some fields to points that I thought might be useful: summed time in queue for the whole job, and the total number of subtasks for each job. 

![Screenshot from 2021-06-25 11-17-07](https://user-images.githubusercontent.com/85509505/123446462-e9478d00-d5a6-11eb-9175-0ced46b3e38f.png)

Here is an example of what querying for summed time in queue for a job might look like:

![Screenshot from 2021-06-25 11-38-39](https://user-images.githubusercontent.com/85509505/123449902-19dcf600-d5aa-11eb-9ca7-70276f176921.png)

Next, I wanted to introduce time in queue data for each individual subtask for a job. 

![Screenshot from 2021-06-25 11-36-32](https://user-images.githubusercontent.com/85509505/123449527-c7033e80-d5a9-11eb-8c84-5cd89e3e9cbd.png)

A map of subtasks mapped to their time in queue is returned using **getSubTaskMap()**. In order to represent each subtask in grafana, fields were added to represent each subtask, where the name (key in map) of the subtask was added as a field. Formatting of the name would be in the formatting "Subtask_#, # being the relative order of when the subtask entered the queue. 

In order to avoid adding too much cardinality to the base, a max number of subtasks to be added as a field was put in place -- 50 subtasks max, represented in static variable _MAX_SUBTASKS._ If the subtask limit is hit, a logger message stating the job name and build number alongside information regarding the subtask threshold will be triggered. However, because of **getSubTaskMap()** returning a hash map, the subtasks that are returned when looping through the map and also when the max threshold is reached **will be random**. It is important to note that in our specific circumstances a 50 subtask limit will almost never be hit, so additional functionality was not added to prevent this.

Here is an example of querying for a specific subtask time in queue:

![Screenshot from 2021-06-25 11-42-56](https://user-images.githubusercontent.com/85509505/123450236-8657f500-d5aa-11eb-8fd3-6fb3cf3df436.png)

In this case, the subtask that is being queried for is subtask 0 -- the first subtask to enter the queue. Each color represents a different job, which is tagged formally in grafana as "project_name".