### PR TITLE
TI-1285-Rebase to influxdb 3.6

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,72 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ development ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ development ]
+  schedule:
+    - cron: '30 1 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+        
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+# Note: additional setup is required, see https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into the default branch
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,7 +5,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - development
 
 jobs:
   update_release_draft:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ release.properties
 *.iml
 .DS_Store
 changes.txt
+
+# Local VS code created hidden directories
+.classpath
+.factorypath
+.project
+.settings/
+.vscode/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 static List<Map<String, String>> recommendedConfigurations() {
-    def recentLTS = "2.263.2"
+    def recentLTS = "2.289.1"
     def configurations = [
         [ platform: "linux", jdk: "8", jenkins: null ],
         [ platform: "windows", jdk: "8", jenkins: null ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,10 @@ static List<Map<String, String>> recommendedConfigurations() {
     def configurations = [
         [ platform: "linux", jdk: "8", jenkins: null ],
         [ platform: "windows", jdk: "8", jenkins: null ],
-        [ platform: "linux", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
-        [ platform: "windows", jdk: "8", jenkins: recentLTS, javaLevel: "8" ],
-        [ platform: "linux", jdk: "11", jenkins: recentLTS, javaLevel: "8" ],
-        [ platform: "windows", jdk: "11", jenkins: recentLTS, javaLevel: "8" ]
+        [ platform: "linux", jdk: "8", jenkins: recentLTS ],
+        [ platform: "windows", jdk: "8", jenkins: recentLTS ],
+        [ platform: "linux", jdk: "11", jenkins: recentLTS ],
+        [ platform: "windows", jdk: "11", jenkins: recentLTS ]
     ]
     return configurations
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,8 @@
 static List<Map<String, String>> recommendedConfigurations() {
-    def recentLTS = "2.289.1"
+    def recentLTS = "2.387.3"
     def configurations = [
-        [ platform: "linux", jdk: "8", jenkins: null ],
-        [ platform: "windows", jdk: "8", jenkins: null ],
-        [ platform: "linux", jdk: "8", jenkins: recentLTS ],
-        [ platform: "windows", jdk: "8", jenkins: recentLTS ],
-        [ platform: "linux", jdk: "11", jenkins: recentLTS ],
-        [ platform: "windows", jdk: "11", jenkins: recentLTS ]
+        [ platform: "linux", jdk: "11", jenkins: recentLTS],
+        [ platform: "windows", jdk: "11", jenkins: recentLTS]
     ]
     return configurations
 }

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ influxdb.removeTarget('my-new-target')
 influxdb.save()
 ```
 
+### Credentials
+
+- InfluxDB 1.8 targets support only `Username with password`.
+- InfluxDB 2.x supports `Username with password` for basic authentication and `Secret Text` for authentication 
+token authentication.
+
 ## Usage
 
 ### Global Listener

--- a/README.md
+++ b/README.md
@@ -268,5 +268,10 @@ Create a pull request to the `development` branch.
 **No pull requests are merged directly to `master`**.
 Comment your changes sufficiently and create appropriate tests.
 
-If you have an idea for a new feature or you want to report a bug,
+For feature requests and bug reports,
 please use the [Jenkins issue tracker](https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20component%20%3D%20influxdb-plugin).
+
+## Acknowledgements
+
+This plugin was inspired by [Jouni Rajala](https://github.com/jrajala-eficode/jenkins-ci.influxdb-plugin)
+and [Christoph Burmeister](http://christoph-burmeister.eu/?p=2906).

--- a/doc/SonarQube_integration.md
+++ b/doc/SonarQube_integration.md
@@ -1,0 +1,179 @@
+# SonarQube API integration
+
+## Summary
+A short guideline on integrating Jenkins with SonarQube and verifying their integration.
+
+The SonarQubePointGenerator is expecting to find a sonar build report (report-task.txt) created by the scanner with the following content:
+```
+file: ${WORKSPACE}/**/sonar/report-task.txt	
+
+projectKey=com.tom:sonarqube-jacoco-code-coverage
+serverUrl=http://localhost:9000
+serverVersion=8.9.3.48735
+dashboardUrl=http://localhost:9000/dashboard?id=com.tom%3Asonarqube-jacoco-code-coverage
+ceTaskId=AX0vnvr4_QGKX8b7Yz_v
+ceTaskUrl=http://localhost:9000/api/ce/task?id=AX0vnvr4_QGKX8b7Yz_v
+```
+
+The actual location of the report file in the workspace depends on the build system used - Maven, Gradle, etc. 
+
+If, for whatever reason, a report file is created with a different name, the `SONARQUBE_BUILD_REPORT_NAME` env var 
+could be used to specify either the file name or the path pattern ending with the file name.
+
+Examples:
+```
+  stage("InfluxDB v2 publisher") {
+    environment {
+        SONARQUBE_BUILD_REPORT_NAME="custom-report.txt"
+        # SONARQUBE_BUILD_REPORT_NAME="path/custom-report.txt"
+    }
+    
+    steps {
+        withSonarQubeEnv('SonarQube') {
+            influxDbPublisher(selectedTarget: 'influxdb_v2',)
+        }
+    }
+  }
+``` 
+
+The information extracted fron this file is used to query about SQ issues, measures and task status.
+
+# References
+1. [CloudBees Video on SonarQube integration with Jenkins](https://www.youtube.com/watch?v=KsTMy0920go)
+2. SonarQube WEB API: https://sonarcloud.io/web_api/
+
+## Verification 
+The plugin is using the following API calls 
+1. [Issues Search](https://sonarcloud.io/web_api/api/issues/search)
+2. [Measures Search Histhory](https://sonarcloud.io/web_api/api/measures/search_history)
+3. [Task CE status](https://sonarcloud.io/web_api/api/ce/task)
+
+After seetting up a security token in SonarQube use the following curl calls to verify manually the API integration
+with SonarQube.
+
+### Measures Search Histhory
+export TOKEN=****************
+curl -s -G -u ${TOKEN}: \
+--data-urlencode "componentKey=com.tom:sonarqube-jacoco-code-coverage" \
+--data-urlencode "component=com.tom:sonarqube-jacoco-code-coverage" \
+--data-urlencode "metricKeys=ncloc" \
+http://localhost:9000/api/measures/component | jq .
+```
+{
+  "component": {
+    "key": "com.tom:sonarqube-jacoco-code-coverage",
+    "name": "sonarqube-jacoco-code-coverage",
+    "qualifier": "TRK",
+    "measures": [
+      {
+        "metric": "ncloc",
+        "value": "9"
+      }
+    ]
+  }
+}
+```
+
+### Issues Search
+export TOKEN=****************
+curl -s -G -u ${TOKEN}: \
+--data-urlencode "componentKeys=com.tom:sonarqube-jacoco-code-coverage" \
+--data-urlencode "resolved=false" \
+--data-urlencode "severities=INFO" \
+http://localhost:9000/api/issues/search?ps=1 | jq .
+
+```
+{
+  "total": 0,
+  "p": 1,
+  "ps": 1,
+  "paging": {
+    "pageIndex": 1,
+    "pageSize": 1,
+    "total": 0
+  },
+  "effortTotal": 0,
+  "issues": [],
+  "components": [],
+  "facets": []
+}
+```
+ 
+### Task status
+export TOKEN=****************
+curl -s -G -u ${TOKEN}: \
+--data-urlencode "id=com.tom:sonarqube-jacoco-code-coverage" \
+http://localhost:9000/api/ce/task?id=AX0vnvr4_QGKX8b7Yz_v | jq .
+```
+{
+  "task": {
+    "id": "AX0vnvr4_QGKX8b7Yz_v",
+    "type": "REPORT",
+    "componentId": "AX0m-2Bde0ytHUET2DEl",
+    "componentKey": "com.tom:sonarqube-jacoco-code-coverage",
+    "componentName": "sonarqube-jacoco-code-coverage",
+    "componentQualifier": "TRK",
+    "analysisId": "AX0vnv7gkMePnxoN1IDV",
+    "status": "SUCCESS",
+    "submittedAt": "2021-11-17T20:38:07+0000",
+    "submitterLogin": "admin",
+    "startedAt": "2021-11-17T20:38:08+0000",
+    "executedAt": "2021-11-17T20:38:22+0000",
+    "executionTimeMs": 13679,
+    "hasScannerContext": true,
+    "warningCount": 0,
+    "warnings": []
+  }
+}
+```
+
+# A simple pipeline for testing
+```
+pipeline {
+    agent any    
+
+    stages {
+        stage('Clone sources') {
+            steps {
+                git url: 'https://github.com/dgeorgievski/sonarqube-jacoco-code-coverage.git'
+            }
+        }        
+        
+        stage('Build') {
+            steps {
+                sh './gradlew clean test build'
+                junit 'build/test-results/test/*.xml'
+                step( [ $class: 'JacocoPublisher' ] )
+            }
+        }
+        
+        stage('SonarQube analysis') {
+            steps {
+                withSonarQubeEnv('SonarQube') {
+                    sh "./gradlew sonarqube -PsonarToken=****************"
+                }
+            }
+        }
+        
+        stage("Quality gate") {
+            steps {
+                waitForQualityGate abortPipeline: true
+            }
+        }
+        
+        stage("InfluxDB v2 publisher") {
+            environment {
+                LOG_JUNIT_RESULTS="true"
+                INFLUXDB_PLUGIN_CUSTOM_PROJECT_NAME = "foo"
+            }
+            
+            steps {
+                withSonarQubeEnv('SonarQube') {
+                    influxDbPublisher(selectedTarget: 'influxdb_v2',)
+                }
+            }
+        }
+        
+    }
+}
+```

--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -360,3 +360,18 @@ Tags specific for this measurement:
 | serenity_results_total_test_duration | integer | Total test duration in milliseconds |  |
 | serenity_tags_* | integer | Amount of tests for each tag |  |
 
+### Metrics plugin
+
+#### `metrics_data` (since 3.4)
+
+| Metric | Type | Description | Introduced in |
+| --- | --- | --- | --- |
+| blocked_time | long | Milliseconds in the queue because build was blocked. | |
+| buildable_time | long | Milliseconds in the queue in a buildable state. | |
+| building_time | long | Milliseconds of the builds | |
+| executing_time | long | Milliseconds building from when it left the queue until it was finished. | |
+| executor_utilization | double | 0-1 percentage of the executor utilization | |
+| queue_time | long | Milliseconds when build entered the queue until it left the queue. | |
+| subtask_count | int | Amount of subtasks | |
+| total_duration | long | Build duration in milliseconds from when it entered the queue until it was finished. | |
+| waiting_time | long | Milliseconds in the queue waiting before it could be considered for execution. | |

--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -6,7 +6,9 @@ All measurements share the following metrics:
 | Metric | Type | Description | Introduced in |
 | --- | --- | --- | --- |
 | build_number | integer | Build number |  |
+| instance | string | Jenkins instance url | 3.4 |
 | project_name | string | Build name |  |
+| project_namespace | string | Root folder of the project | 3.4 |
 | project_path | string | Build path | 1.15 |
 
 All measurements share the following tags:
@@ -28,6 +30,7 @@ All measurements share the following tags:
 | --- | --- | --- | --- |
 | build_agent_name | string | Name of the executor node | 1.15 |
 | build_branch_name | string | Branch name of multibranch pipeline | 2.4 |
+| build_cause | string | Trigger type | 3.4 |
 | build_causer | string | Short description of build causer| 2.4 |
 | build_exec_time | integer | Start time of the build | 1.17 |
 | build_measured_time | integer | Time when InfluxDB plugin is called | 1.17 |
@@ -37,6 +40,7 @@ All measurements share the following tags:
 | build_status_message | string | Status message (stable, back to normal, broken since #50, etc.) | |
 | build_successful | boolean | Boolean whether build succeeded | 1.10 |
 | build_time | integer | Build execution time |  |
+| build_user | string | User who launch the build | 3.4 |
 | last_stable_build | integer | Build number of the last stable build (0 if never) | 1.10 |
 | last_successful_build | integer | Build number of the last successful build (0 if never) | 1.10 |
 | project_build_health | integer | Health score from build | |

--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -74,8 +74,8 @@ In order to publish data for this measurement, your job needs to set an environm
 | test_status | string | PASSED, SKIPPED, FAILED, FIXED, REGRESSION | |
 | test_status_ordinal | integer | 0-4 in order of test_status | |
 | test_duration | float | test duration in seconds | |
-| test_duration | float | test duration in seconds | |
-| test_count | long | Test counter; Useful for aggregations. ||
+| test_duration | float | test duration in seconds | 3.1 |
+| test_count | long | Test counter; Useful for aggregations. | 3.1 |
 
 Tags specific for this measurement:
 
@@ -92,7 +92,7 @@ Tags specific for this measurement:
 | Metric | Type | Description | Introduced in |
 | --- | --- | --- | --- |
 | alert_status | string | State of the Quality Gate | 2.4 |
-| quality_gate_details | string | Provides which quality gate condition is failing and which is not.| 3.0.3 |
+| quality_gate_details | string | Provides which quality gate condition is failing and which is not.| 3.1 |
 | blocker_issues | float | Total amount of blocker issues | |
 | branch_coverage | float | Branch coverage | 2.2 |
 | bugs | float | Total amount of bugs | 2.2 |

--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -92,6 +92,7 @@ Tags specific for this measurement:
 | Metric | Type | Description | Introduced in |
 | --- | --- | --- | --- |
 | alert_status | string | State of the Quality Gate | 2.4 |
+| quality_gate_details | string | Provides which quality gate condition is failing and which is not.| 3.0.3 |
 | blocker_issues | float | Total amount of blocker issues | |
 | branch_coverage | float | Branch coverage | 2.2 |
 | bugs | float | Total amount of bugs | 2.2 |

--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -378,3 +378,12 @@ Tags specific for this measurement:
 | subtask_count | int | Amount of subtasks | |
 | total_duration | long | Build duration in milliseconds from when it entered the queue until it was finished. | |
 | waiting_time | long | Milliseconds in the queue waiting before it could be considered for execution. | |
+
+### Git plugin
+
+#### `git_data` (since 3.4)
+| Metric | Type | Description | Introduced in |
+| --- | --- | --- | --- |
+| git_repository | string | URL of the Git repository used by the build | |
+| git_revision | string | SHA-1 of the commit selected | |
+| git_reference | string | reference of the branch | |

--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -74,6 +74,8 @@ In order to publish data for this measurement, your job needs to set an environm
 | test_status | string | PASSED, SKIPPED, FAILED, FIXED, REGRESSION | |
 | test_status_ordinal | integer | 0-4 in order of test_status | |
 | test_duration | float | test duration in seconds | |
+| test_duration | float | test duration in seconds | |
+| test_count | long | Test counter; Useful for aggregations. ||
 
 Tags specific for this measurement:
 

--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -43,7 +43,7 @@ All measurements share the following tags:
 | tests_failed | integer | Amount of failed unit tests (from JUnit plugin) | |
 | tests_skipped | integer | Amount of skipped unit tests (from JUnit plugin) | |
 | tests_total | integer | total amount of unit tests (from JUnit plugin) | |
-| time_in_queue | integer | Time build was in queue (from Metrics plugin | 1.16 |
+| time_in_queue | integer | Time build was in queue (from Metrics plugin) | 1.16 |
 
 Tags specific for this measurement:
 

--- a/doc/available_metrics.md
+++ b/doc/available_metrics.md
@@ -112,8 +112,11 @@ Tags specific for this measurement:
 | sqale_index | float | Technical Debt | 2.4 |
 | sqale_debt_ratio | float | Technical Debt Ratio | 2.4 |
 
-
-
+#### `agent_data` (since 3.4)
+| Metric | Type | Description | Introduced in |
+| --- | --- | --- | --- |
+| agent_name | string | Name of an agent called by the build |  |
+| agent_label | string | Label of an agent called by the build |  |
 
 ### Cobertura plugin
 

--- a/doc/breaking_changes.md
+++ b/doc/breaking_changes.md
@@ -2,6 +2,7 @@
 
 ## 3.0
 
+- InfluxDB 1.7 and lower are no longer supported. Only supported 1.x version is 1.8.x.
 - "username" and "password" are no longer used when defining new InfluxDB Targets.
 Credentials are used instead. Please check your InfluxDB Target configurations from
 Manage Jenkins --> Configure System.

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.6</version>
+    <version>3.6-CUSTOM</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -63,7 +63,7 @@ THE SOFTWARE.
         <junit_plugin.version>1166.va_436e268e972</junit_plugin.version>
         <kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>
         <matrix-project.version>1.20</matrix-project.version>
-        <metrics.version>4.0.2.8.1</metrics.version>
+        <metrics.version>4.1.6-CUSTOM</metrics.version>
         <mockito-core.version>3.3.3</mockito-core.version>
         <performance.version>3.0</performance.version>
         <perfpublisher.version>8.05</perfpublisher.version>
@@ -106,12 +106,6 @@ THE SOFTWARE.
                 <version>2143.ve4c3c9ec790a</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-durable-task-step</artifactId>
-                <version>2.35</version>
-                <optional>true</optional>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -307,6 +301,7 @@ THE SOFTWARE.
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
         </dependency>
+
     </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 The MIT License (MIT)
-
 Copyright (c) 2016- Eficode Ltd
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,18 +20,15 @@ THE SOFTWARE.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>4.66</version>
     </parent>
-
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
     <version>3.6</version>
     <packaging>hpi</packaging>
-
     <name>InfluxDB Plugin</name>
     <description>Push time series data from other plugins to InfluxDB</description>
 
@@ -45,7 +38,6 @@ THE SOFTWARE.
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
         <tag>influxdb-3.6</tag>
     </scm>
-
     <properties>
         <cobertura.version>1.16</cobertura.version>
         <commons-csv.version>1.8</commons-csv.version>
@@ -72,7 +64,6 @@ THE SOFTWARE.
         <script-security.version>1244.ve463715a_f89c</script-security.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
     </properties>
-
     <licenses>
         <license>
             <name>MIT license</name>
@@ -80,7 +71,6 @@ THE SOFTWARE.
             <comments>All source code is under the MIT license.</comments>
         </license>
     </licenses>
-
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -97,7 +87,6 @@ THE SOFTWARE.
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -107,9 +96,14 @@ THE SOFTWARE.
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-durable-task-step</artifactId>
+                <version>2.35</version>
+                <optional>true</optional>
+            </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.ow2.asm</groupId>
@@ -301,7 +295,6 @@ THE SOFTWARE.
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
         </dependency>
-
     </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 The MIT License (MIT)
+
 Copyright (c) 2016- Eficode Ltd
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
+
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/pom.xml
+++ b/pom.xml
@@ -20,15 +20,18 @@ THE SOFTWARE.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>4.66</version>
     </parent>
+
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
     <version>3.6</version>
     <packaging>hpi</packaging>
+
     <name>InfluxDB Plugin</name>
     <description>Push time series data from other plugins to InfluxDB</description>
 
@@ -38,6 +41,7 @@ THE SOFTWARE.
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
         <tag>influxdb-3.6</tag>
     </scm>
+
     <properties>
         <cobertura.version>1.16</cobertura.version>
         <commons-csv.version>1.8</commons-csv.version>
@@ -64,6 +68,7 @@ THE SOFTWARE.
         <script-security.version>1244.ve463715a_f89c</script-security.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
     </properties>
+
     <licenses>
         <license>
             <name>MIT license</name>
@@ -71,6 +76,7 @@ THE SOFTWARE.
             <comments>All source code is under the MIT license.</comments>
         </license>
     </licenses>
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -87,6 +93,7 @@ THE SOFTWARE.
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -104,6 +111,7 @@ THE SOFTWARE.
             </dependency>
         </dependencies>
     </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.ow2.asm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,6 @@ THE SOFTWARE.
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
             <version>${workflow-api.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.0.3-SNAPSHOT</version>
+    <version>3.1</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>influxdb-3.1</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>influxdb-3.1.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,9 @@ THE SOFTWARE.
         <commons-lang3.version>3.11</commons-lang3.version>
         <configuration-as-code.version>1.55.1</configuration-as-code.version>
         <credentials.version>2.6.1.1</credentials.version>
+        <display-url-api.version>2.3.5</display-url-api.version>
         <doxia-sink-api.version>1.1.2</doxia-sink-api.version>
-        <git-plugin.version>3.9.1</git-plugin.version>
+        <git-plugin.version>4.11.4</git-plugin.version>
         <gson.version>2.8.9</gson.version>
         <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
         <influxdb-client-java.version>4.1.0</influxdb-client-java.version>
@@ -68,10 +69,11 @@ THE SOFTWARE.
         <jenkins.version>2.289.1</jenkins.version>
         <jimfs.version>1.0</jimfs.version>
         <junit.version>4.13.1</junit.version>
-        <junit_plugin.version>1.24</junit_plugin.version>
+        <junit_plugin.version>1.47</junit_plugin.version>
         <kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>
-        <mailer.version>391.ve4a_38c1b_cf4b_</mailer.version>
+        <mailer.version>408.vd726a_1130320</mailer.version>
         <maven-reporting-api.version>3.0</maven-reporting-api.version>
+        <matrix-project.version>1.20</matrix-project.version>
         <metrics.version>4.0.2.8.1</metrics.version>
         <mockito-core.version>2.26.0</mockito-core.version>
         <performance.version>3.0</performance.version>
@@ -80,14 +82,15 @@ THE SOFTWARE.
         <plexus-container-default.version>1.0-alpha-30</plexus-container-default.version>
         <plain-credentials.version>1.7</plain-credentials.version>
         <robot.version>3.0.0</robot.version>
-        <script-security.version>1.75</script-security.version>
+        <scm-api.version>595.vd5a_df5eb_0e39</scm-api.version>
+        <script-security.version>1131.v8b_b_5eda_c328e</script-security.version>
         <slf4j.version>1.7.30</slf4j.version>
         <spotbugs-annotations.version>4.2.0</spotbugs-annotations.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
-        <structs.version>1.23</structs.version>
+        <structs.version>308.v852b473a2b8c</structs.version>
         <symbol-annotation.version>1.10</symbol-annotation.version>
-        <workflow-api.version>2.33</workflow-api.version>
-        <workflow-step-api.version>2.20</workflow-step-api.version>
+        <workflow-api.version>2.40</workflow-api.version>
+        <workflow-step-api.version>622.vb_8e7c15b_c95a_</workflow-step-api.version>
         <workflow-durable-task-step.version>2.35</workflow-durable-task-step.version>
     </properties>
 
@@ -240,6 +243,12 @@ THE SOFTWARE.
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>${git-plugin.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jacoco</artifactId>
             <version>${jacoco.version}</version>
             <optional>true</optional>
@@ -277,6 +286,11 @@ THE SOFTWARE.
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>${matrix-project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
             <version>${workflow-durable-task-step.version}</version>
@@ -293,6 +307,11 @@ THE SOFTWARE.
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>${caffeine.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>display-url-api</artifactId>
+            <version>${display-url-api.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
@@ -332,6 +351,11 @@ THE SOFTWARE.
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>${scm-api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <version>${slf4j.version}</version>
@@ -350,12 +374,6 @@ THE SOFTWARE.
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
-            <version>${git-plugin.version}</version>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@ THE SOFTWARE.
         <cobertura.version>1.12.1</cobertura.version>
         <commons-csv.version>1.8</commons-csv.version>
         <commons-lang3.version>3.11</commons-lang3.version>
-        <configuration-as-code.version>1.51</configuration-as-code.version>
+        <configuration-as-code.version>1.55</configuration-as-code.version>
         <credentials.version>2.6.1.1</credentials.version>
         <doxia-sink-api.version>1.1.2</doxia-sink-api.version>
         <gson.version>2.8.8</gson.version>
@@ -60,7 +60,7 @@ THE SOFTWARE.
         <influxdb-client-java.version>4.1.0</influxdb-client-java.version>
         <jacoco.version>1.0.12</jacoco.version>
         <java.level>8</java.level>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.249.1</jenkins.version>
         <jimfs.version>1.0</jimfs.version>
         <junit.version>4.13.1</junit.version>
         <kotlin-stdlib.version>1.3.71</kotlin-stdlib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ THE SOFTWARE.
         <bridge-method-annotation.version>1.18</bridge-method-annotation.version>
         <byte-buddy.version>1.9.10</byte-buddy.version>
         <caffeine.version>2.9.2</caffeine.version>
-        <cobertura.version>1.12.1</cobertura.version>
+        <cobertura.version>1.16</cobertura.version>
         <commons-csv.version>1.8</commons-csv.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <configuration-as-code.version>1.55.1</configuration-as-code.version>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>com.influxdb</groupId>
             <artifactId>influxdb-client-java</artifactId>
-            <version>1.15.0</version>
+            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -266,7 +266,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.8</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
 
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
         <tag>HEAD</tag>
     </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ THE SOFTWARE.
         <jacoco.version>3.3.2.1</jacoco.version>
         <jenkins.version>2.387.3</jenkins.version>
         <junit.version>4.13.2</junit.version>
-        <junit_plugin.version>1.47</junit_plugin.version>
+        <junit_plugin.version>1166.va_436e268e972</junit_plugin.version>
         <kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>
         <matrix-project.version>1.20</matrix-project.version>
         <metrics.version>4.0.2.8.1</metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.4</version>
+    <version>3.4.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>influxdb-3.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.4.1-SNAPSHOT</version>
+    <version>3.5</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>influxdb-3.5</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.2-SNAPSHOT</version>
+    <version>3.1.1</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>influxdb-3.1.1</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ THE SOFTWARE.
         <jenkins.version>2.249.1</jenkins.version>
         <jimfs.version>1.0</jimfs.version>
         <junit.version>4.13.1</junit.version>
-        <junit_plugin.version>1.23</junit_plugin.version>
+        <junit_plugin.version>1.24</junit_plugin.version>
         <kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>
         <mailer.version>1.20</mailer.version>
         <maven-reporting-api.version>3.0</maven-reporting-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.0.2</version>
+    <version>3.0.3-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>influxdb-3.0.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ THE SOFTWARE.
         <credentials.version>2.6.1.1</credentials.version>
         <display-url-api.version>2.3.5</display-url-api.version>
         <doxia-sink-api.version>1.1.2</doxia-sink-api.version>
-        <git-plugin.version>4.11.4</git-plugin.version>
+        <git-plugin.version>4.11.5</git-plugin.version>
         <gson.version>2.8.9</gson.version>
         <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
         <influxdb-client-java.version>4.1.0</influxdb-client-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.2</version>
+    <version>3.3-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>influxdb-3.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.1.2</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>influxdb-3.1.2</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,12 @@ THE SOFTWARE.
             <version>${workflow-api.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>plain-credentials</artifactId>
+            <version>1.7</version>
+        </dependency>
+
 
 
         <!-- RequireUpperBounds fix -->

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,11 @@ THE SOFTWARE.
     </scm>
 
     <properties>
-        <asm.version>5.0.3</asm.version>
+        <access-modifier-annotation.version>1.21</access-modifier-annotation.version>
+        <annotation-indexer.version>1.14</annotation-indexer.version>
+        <asm.version>9.1</asm.version>
         <byte-buddy.version>1.9.10</byte-buddy.version>
+        <caffeine.version>2.9.2</caffeine.version>
         <cobertura.version>1.12.1</cobertura.version>
         <commons-csv.version>1.8</commons-csv.version>
         <commons-lang3.version>3.11</commons-lang3.version>
@@ -60,12 +63,12 @@ THE SOFTWARE.
         <influxdb-client-java.version>4.1.0</influxdb-client-java.version>
         <jacoco.version>1.0.12</jacoco.version>
         <java.level>8</java.level>
-        <jenkins.version>2.249.1</jenkins.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <jimfs.version>1.0</jimfs.version>
         <junit.version>4.13.1</junit.version>
         <junit_plugin.version>1.24</junit_plugin.version>
         <kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>
-        <mailer.version>1.20</mailer.version>
+        <mailer.version>391.ve4a_38c1b_cf4b_</mailer.version>
         <maven-reporting-api.version>3.0</maven-reporting-api.version>
         <metrics.version>4.0.2.8.1</metrics.version>
         <mockito-core.version>2.26.0</mockito-core.version>
@@ -75,8 +78,9 @@ THE SOFTWARE.
         <plexus-container-default.version>1.0-alpha-30</plexus-container-default.version>
         <plain-credentials.version>1.7</plain-credentials.version>
         <robot.version>3.0.0</robot.version>
-        <script-security.version>1.58</script-security.version>
+        <script-security.version>1.75</script-security.version>
         <slf4j.version>1.7.30</slf4j.version>
+        <spotbugs-annotations.version>4.2.0</spotbugs-annotations.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
         <structs.version>1.23</structs.version>
         <symbol-annotation.version>1.10</symbol-annotation.version>
@@ -280,6 +284,16 @@ THE SOFTWARE.
             <version>${commons-csv.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${caffeine.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>${spotbugs-annotations.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
@@ -296,9 +310,20 @@ THE SOFTWARE.
             <version>${kotlin-stdlib.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>annotation-indexer</artifactId>
+            <version>${annotation-indexer.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
             <version>${script-security.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>access-modifier-annotation</artifactId>
+            <version>${access-modifier-annotation.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@ THE SOFTWARE.
         <slf4j.version>1.7.30</slf4j.version>
         <spotbugs-annotations.version>4.2.0</spotbugs-annotations.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
+        <sshd.version>3.0</sshd.version>
         <structs.version>308.v852b473a2b8c</structs.version>
         <symbol-annotation.version>1.10</symbol-annotation.version>
         <workflow-api.version>2.40</workflow-api.version>
@@ -232,6 +233,12 @@ THE SOFTWARE.
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <version>${workflow-step-api.version}</version>
+        </dependency>
+        <dependency>
+             <groupId>org.jenkins-ci.modules</groupId>
+             <artifactId>sshd</artifactId>
+            <version>${sshd.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Optional dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>influxdb-3.3</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.5</version>
+    <version>3.5.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>influxdb-3.5</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.2.1</version>
+    <version>3.2.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>influxdb-3.2.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.1</version>
+    <version>3.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>influxdb-3.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@ THE SOFTWARE.
         <cobertura.version>1.12.1</cobertura.version>
         <commons-csv.version>1.8</commons-csv.version>
         <commons-lang3.version>3.11</commons-lang3.version>
-        <configuration-as-code.version>1.55</configuration-as-code.version>
+        <configuration-as-code.version>1.55.1</configuration-as-code.version>
         <credentials.version>2.6.1.1</credentials.version>
         <doxia-sink-api.version>1.1.2</doxia-sink-api.version>
         <gson.version>2.8.8</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@ THE SOFTWARE.
         <mockito-core.version>2.26.0</mockito-core.version>
         <performance.version>3.0</performance.version>
         <perfpublisher.version>8.05</perfpublisher.version>
-        <plexus-utils.version>1.5.12</plexus-utils.version>
+        <plexus-utils.version>3.0.16</plexus-utils.version>
         <plexus-container-default.version>1.0-alpha-30</plexus-container-default.version>
         <plain-credentials.version>1.7</plain-credentials.version>
         <robot.version>3.0.0</robot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.3</version>
+    <version>3.3.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>influxdb-3.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.3-SNAPSHOT</version>
+    <version>3.2.1</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>influxdb-3.2.1</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@ THE SOFTWARE.
         <jimfs.version>1.0</jimfs.version>
         <junit.version>4.13.1</junit.version>
         <junit_plugin.version>1.23</junit_plugin.version>
-        <kotlin-stdlib.version>1.3.71</kotlin-stdlib.version>
+        <kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>
         <mailer.version>1.20</mailer.version>
         <maven-reporting-api.version>3.0</maven-reporting-api.version>
         <metrics.version>4.0.2.8.1</metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.4</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>influxdb-3.4</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.50</version>
+        <version>4.66</version>
     </parent>
 
     <artifactId>influxdb</artifactId>
@@ -41,58 +41,36 @@ THE SOFTWARE.
 
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
+        <developerConnection>scm:git:git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
         <tag>HEAD</tag>
     </scm>
 
     <properties>
-        <access-modifier-annotation.version>1.21</access-modifier-annotation.version>
-        <annotation-indexer.version>1.14</annotation-indexer.version>
-        <asm.version>9.1</asm.version>
-        <bridge-method-annotation.version>1.18</bridge-method-annotation.version>
-        <byte-buddy.version>1.9.10</byte-buddy.version>
-        <caffeine.version>2.9.2</caffeine.version>
         <cobertura.version>1.16</cobertura.version>
         <commons-csv.version>1.8</commons-csv.version>
-        <commons-lang3.version>3.11</commons-lang3.version>
-        <configuration-as-code.version>1.55.1</configuration-as-code.version>
-        <credentials.version>2.6.1.1</credentials.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
+        <configuration-as-code.version>1625.v27444588cc3d</configuration-as-code.version>
+        <credentials.version>1189.vf61b_a_5e2f62e</credentials.version>
         <display-url-api.version>2.3.5</display-url-api.version>
-        <doxia-sink-api.version>1.1.2</doxia-sink-api.version>
         <git-plugin.version>4.11.5</git-plugin.version>
         <gson.version>2.8.9</gson.version>
         <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
         <influxdb-client-java.version>4.1.0</influxdb-client-java.version>
         <jacoco.version>1.0.12</jacoco.version>
-        <java.level>8</java.level>
-        <jenkins.version>2.289.1</jenkins.version>
-        <jimfs.version>1.0</jimfs.version>
-        <junit.version>4.13.1</junit.version>
+        <jenkins.version>2.387.3</jenkins.version>
+        <junit.version>4.13.2</junit.version>
         <junit_plugin.version>1.47</junit_plugin.version>
         <kotlin-stdlib.version>1.6.0</kotlin-stdlib.version>
-        <mailer.version>408.vd726a_1130320</mailer.version>
-        <maven-reporting-api.version>3.0</maven-reporting-api.version>
         <matrix-project.version>1.20</matrix-project.version>
         <metrics.version>4.0.2.8.1</metrics.version>
-        <mockito-core.version>2.26.0</mockito-core.version>
+        <mockito-core.version>3.3.3</mockito-core.version>
         <performance.version>3.0</performance.version>
         <perfpublisher.version>8.05</perfpublisher.version>
-        <plexus-utils.version>3.0.16</plexus-utils.version>
-        <plexus-container-default.version>1.0-alpha-30</plexus-container-default.version>
-        <plain-credentials.version>1.7</plain-credentials.version>
+        <plain-credentials.version>143.v1b_df8b_d3b_e48</plain-credentials.version>
         <robot.version>3.0.0</robot.version>
-        <scm-api.version>595.vd5a_df5eb_0e39</scm-api.version>
-        <script-security.version>1131.v8b_b_5eda_c328e</script-security.version>
-        <slf4j.version>1.7.30</slf4j.version>
-        <spotbugs-annotations.version>4.2.0</spotbugs-annotations.version>
+        <script-security.version>1244.ve463715a_f89c</script-security.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
-        <sshd.version>3.0</sshd.version>
-        <structs.version>308.v852b473a2b8c</structs.version>
-        <symbol-annotation.version>1.10</symbol-annotation.version>
-        <workflow-api.version>2.40</workflow-api.version>
-        <workflow-step-api.version>622.vb_8e7c15b_c95a_</workflow-step-api.version>
-        <workflow-durable-task-step.version>2.35</workflow-durable-task-step.version>
     </properties>
 
     <licenses>
@@ -108,10 +86,10 @@ THE SOFTWARE.
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
-		<repository>
-			<id>maven.jenkins-ci.org</id>
-			<url>https://repo.jenkins-ci.org/releases/</url>
-		</repository>
+        <repository>
+            <id>maven.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/releases/</url>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
@@ -123,64 +101,36 @@ THE SOFTWARE.
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-commons</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-tree</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy-agent</artifactId>
-                <version>${byte-buddy.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.doxia</groupId>
-                <artifactId>doxia-sink-api</artifactId>
-                <version>${doxia-sink-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.reporting</groupId>
-                <artifactId>maven-reporting-api</artifactId>
-                <version>${maven-reporting-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-container-default</artifactId>
-                <version>${plexus-container-default.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <version>${plexus-utils.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>structs</artifactId>
-                <version>${structs.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>symbol-annotation</artifactId>
-                <version>${symbol-annotation.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.infradna.tool</groupId>
-                <artifactId>bridge-method-annotation</artifactId>
-                <version>${bridge-method-annotation.version}</version>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2143.ve4c3c9ec790a</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-tree</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>symbol-annotation</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -227,18 +177,10 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>${workflow-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api.version}</version>
-        </dependency>
-        <dependency>
-             <groupId>org.jenkins-ci.modules</groupId>
-             <artifactId>sshd</artifactId>
-            <version>${sshd.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- Optional dependencies -->
@@ -288,20 +230,17 @@ THE SOFTWARE.
         <!-- Transitive dependencies -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>mailer</artifactId>
-            <version>${mailer.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <version>${matrix-project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>${workflow-durable-task-step.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
         </dependency>
 
         <!-- RequireUpperBounds fix -->
@@ -311,30 +250,12 @@ THE SOFTWARE.
             <version>${commons-csv.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-            <version>${caffeine.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>display-url-api</artifactId>
-            <version>${display-url-api.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-            <version>${spotbugs-annotations.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>${gson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.jimfs</groupId>
-            <artifactId>jimfs</artifactId>
-            <version>${jimfs.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -344,7 +265,6 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>annotation-indexer</artifactId>
-            <version>${annotation-indexer.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -354,34 +274,34 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>access-modifier-annotation</artifactId>
-            <version>${access-modifier-annotation.version}</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-            <version>${scm-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
+        <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>ssh-credentials</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+
     </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.1.2</version>
+    <version>3.1.3-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>influxdb-3.1.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@ THE SOFTWARE.
         <access-modifier-annotation.version>1.21</access-modifier-annotation.version>
         <annotation-indexer.version>1.14</annotation-indexer.version>
         <asm.version>9.1</asm.version>
+        <bridge-method-annotation.version>1.18</bridge-method-annotation.version>
         <byte-buddy.version>1.9.10</byte-buddy.version>
         <caffeine.version>2.9.2</caffeine.version>
         <cobertura.version>1.12.1</cobertura.version>
@@ -58,6 +59,7 @@ THE SOFTWARE.
         <configuration-as-code.version>1.55.1</configuration-as-code.version>
         <credentials.version>2.6.1.1</credentials.version>
         <doxia-sink-api.version>1.1.2</doxia-sink-api.version>
+        <git-plugin.version>3.9.1</git-plugin.version>
         <gson.version>2.8.9</gson.version>
         <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
         <influxdb-client-java.version>4.1.0</influxdb-client-java.version>
@@ -165,6 +167,11 @@ THE SOFTWARE.
                 <groupId>org.jenkins-ci</groupId>
                 <artifactId>symbol-annotation</artifactId>
                 <version>${symbol-annotation.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.infradna.tool</groupId>
+                <artifactId>bridge-method-annotation</artifactId>
+                <version>${bridge-method-annotation.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -343,6 +350,12 @@ THE SOFTWARE.
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>${git-plugin.version}</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@ THE SOFTWARE.
         <configuration-as-code.version>1.55.1</configuration-as-code.version>
         <credentials.version>2.6.1.1</credentials.version>
         <doxia-sink-api.version>1.1.2</doxia-sink-api.version>
-        <gson.version>2.8.8</gson.version>
+        <gson.version>2.8.9</gson.version>
         <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
         <influxdb-client-java.version>4.1.0</influxdb-client-java.version>
         <jacoco.version>1.0.12</jacoco.version>
@@ -63,6 +63,7 @@ THE SOFTWARE.
         <jenkins.version>2.249.1</jenkins.version>
         <jimfs.version>1.0</jimfs.version>
         <junit.version>4.13.1</junit.version>
+        <junit_plugin.version>1.23</junit_plugin.version>
         <kotlin-stdlib.version>1.3.71</kotlin-stdlib.version>
         <mailer.version>1.20</mailer.version>
         <maven-reporting-api.version>3.0</maven-reporting-api.version>
@@ -191,6 +192,11 @@ THE SOFTWARE.
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit_plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,13 @@ THE SOFTWARE.
             <version>1.3.71</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <!-- The current maintainers of the plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.5.1-SNAPSHOT</version>
+    <version>3.6</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>influxdb-3.6</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>influxdb-3.0.2</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://github.com/jenkinsci/influxdb-plugin</url>
-    <version>3.1.3-SNAPSHOT</version>
+    <version>3.2</version>
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>influxdb-3.2</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ THE SOFTWARE.
         <gson.version>2.8.9</gson.version>
         <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
         <influxdb-client-java.version>4.1.0</influxdb-client-java.version>
-        <jacoco.version>1.0.12</jacoco.version>
+        <jacoco.version>3.3.2.1</jacoco.version>
         <jenkins.version>2.387.3</jenkins.version>
         <junit.version>4.13.2</junit.version>
         <junit_plugin.version>1.47</junit_plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@ THE SOFTWARE.
     <packaging>hpi</packaging>
 
     <name>InfluxDB Plugin</name>
-    <description>Plugin for pushing time series data to InfluxDB, inspired by https://github.com/jrajala-eficode/jenkins-ci.influxdb-plugin and http://christoph-burmeister.eu/?p=2906</description>
+    <description>Push time series data from other plugins to InfluxDB</description>
 
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
@@ -47,14 +47,41 @@ THE SOFTWARE.
     </scm>
 
     <properties>
+        <asm.version>5.0.3</asm.version>
+        <byte-buddy.version>1.9.10</byte-buddy.version>
+        <cobertura.version>1.12.1</cobertura.version>
+        <commons-csv.version>1.8</commons-csv.version>
+        <commons-lang3.version>3.11</commons-lang3.version>
+        <configuration-as-code.version>1.51</configuration-as-code.version>
+        <credentials.version>2.6.1.1</credentials.version>
+        <doxia-sink-api.version>1.1.2</doxia-sink-api.version>
+        <gson.version>2.8.8</gson.version>
         <hpi.compatibleSinceVersion>3.0</hpi.compatibleSinceVersion>
+        <influxdb-client-java.version>4.1.0</influxdb-client-java.version>
+        <jacoco.version>1.0.12</jacoco.version>
         <java.level>8</java.level>
         <jenkins.version>2.222.4</jenkins.version>
+        <jimfs.version>1.0</jimfs.version>
+        <junit.version>4.13.1</junit.version>
+        <kotlin-stdlib.version>1.3.71</kotlin-stdlib.version>
         <mailer.version>1.20</mailer.version>
+        <maven-reporting-api.version>3.0</maven-reporting-api.version>
+        <metrics.version>4.0.2.8.1</metrics.version>
+        <mockito-core.version>2.26.0</mockito-core.version>
+        <performance.version>3.0</performance.version>
+        <perfpublisher.version>8.05</perfpublisher.version>
+        <plexus-utils.version>1.5.12</plexus-utils.version>
+        <plexus-container-default.version>1.0-alpha-30</plexus-container-default.version>
+        <plain-credentials.version>1.7</plain-credentials.version>
+        <robot.version>3.0.0</robot.version>
+        <script-security.version>1.58</script-security.version>
         <slf4j.version>1.7.30</slf4j.version>
         <spotbugs.failOnError>false</spotbugs.failOnError>
-        <workflow-api.version>2.30</workflow-api.version>
-        <workflow-step-api.version>2.19</workflow-step-api.version>
+        <structs.version>1.23</structs.version>
+        <symbol-annotation.version>1.10</symbol-annotation.version>
+        <workflow-api.version>2.33</workflow-api.version>
+        <workflow-step-api.version>2.20</workflow-step-api.version>
+        <workflow-durable-task-step.version>2.35</workflow-durable-task-step.version>
     </properties>
 
     <licenses>
@@ -85,149 +112,96 @@ THE SOFTWARE.
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>structs</artifactId>
-                <version>1.22</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>symbol-annotation</artifactId>
-                <version>1.10</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <version>1.5.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-container-default</artifactId>
-                <version>1.0-alpha-30</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.reporting</groupId>
-                <artifactId>maven-reporting-api</artifactId>
-                <version>3.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.doxia</groupId>
-                <artifactId>doxia-sink-api</artifactId>
-                <version>1.1.2</version>
-            </dependency>
-            <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>5.0.3</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-tree</artifactId>
-                <version>5.0.3</version>
+                <version>${asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-commons</artifactId>
-                <version>5.0.3</version>
+                <version>${asm.version}</version>
             </dependency>
             <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>1.9.10</version>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-tree</artifactId>
+                <version>${asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy-agent</artifactId>
-                <version>1.9.10</version>
+                <version>${byte-buddy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.doxia</groupId>
+                <artifactId>doxia-sink-api</artifactId>
+                <version>${doxia-sink-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven.reporting</groupId>
+                <artifactId>maven-reporting-api</artifactId>
+                <version>${maven-reporting-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-container-default</artifactId>
+                <version>${plexus-container-default.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${plexus-utils.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>structs</artifactId>
+                <version>${structs.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci</groupId>
+                <artifactId>symbol-annotation</artifactId>
+                <version>${symbol-annotation.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>${configuration-as-code.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>${credentials.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.influxdb</groupId>
             <artifactId>influxdb-client-java</artifactId>
-            <version>4.1.0</version>
+            <version>${influxdb-client-java.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.26.0</version>
+            <version>${mockito-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.jenkins</groupId>
-            <artifactId>configuration-as-code</artifactId>
-            <version>1.48</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.11</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>cobertura</artifactId>
-            <version>1.12.1</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>credentials</artifactId>
-            <version>2.3.19</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>jacoco</artifactId>
-            <version>1.0.12</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>junit</artifactId>
-            <version>1.23</version>
-        </dependency>
-        <dependency> <!-- Transitive dependency -->
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>mailer</artifactId>
-            <version>${mailer.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>metrics</artifactId>
-            <version>3.1.2.9</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>performance</artifactId>
-            <version>3.0</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>perfpublisher</artifactId>
-            <version>8.05</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>robot</artifactId>
-            <version>3.0.0</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api.version}</version>
+            <artifactId>plain-credentials</artifactId>
+            <version>${plain-credentials.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -236,22 +210,93 @@ THE SOFTWARE.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>plain-credentials</artifactId>
-            <version>1.7</version>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>${workflow-step-api.version}</version>
         </dependency>
 
+        <!-- Optional dependencies -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cobertura</artifactId>
+            <version>${cobertura.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jacoco</artifactId>
+            <version>${jacoco.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>metrics</artifactId>
+            <version>${metrics.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>performance</artifactId>
+            <version>${performance.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>perfpublisher</artifactId>
+            <version>${perfpublisher.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>robot</artifactId>
+            <version>${robot.version}</version>
+            <optional>true</optional>
+        </dependency>
 
+        <!-- Transitive dependencies -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>mailer</artifactId>
+            <version>${mailer.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>${workflow-durable-task-step.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- RequireUpperBounds fix -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>${commons-csv.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>${jimfs.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin-stdlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>script-security</artifactId>
+            <version>${script-security.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <artifactId>jcl-over-slf4j</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
@@ -261,33 +306,16 @@ THE SOFTWARE.
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
+            <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-csv</artifactId>
-            <version>1.8</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
-            <version>1.3.71</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.jimfs</groupId>
-            <artifactId>jimfs</artifactId>
-            <version>1.0</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
+
 
     <!-- The current maintainers of the plugin -->
     <developers>

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -277,6 +277,16 @@ public class InfluxDbPublicationService {
             logger.log(Level.FINE, "Plugin skipped: Performance Publisher");
         }
 
+        try {
+            MetricsPointGenerator metricsGen = new MetricsPointGenerator(build, listener, measurementRenderer, timestamp, jenkinsEnvParameterTag, customPrefix);
+            if (metricsGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB plugin] Metrics plugin data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, metricsGen, listener);
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.FINE, "Plugin skipped: Metrics");
+        }
+
         for (Target target : selectedTargets) {
             URL url;
             try {

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -65,7 +65,7 @@ public class InfluxDbPublicationService {
      * def myFields = [:]
      * myFields['field_a'] = 11
      * myFields['field_b'] = 12
-     * influxDbPublisher(target: 'my-target', customData: myFields)
+     * influxDbPublisher(selectedTarget: 'my-target', customData: myFields)
      * }</pre>
      */
     private final Map<String, Object> customData;
@@ -79,7 +79,7 @@ public class InfluxDbPublicationService {
      * def myTags = [:]
      * myTags['tag_1'] = 'foo'
      * myTags['tag_2'] = 'bar'
-     * influxDbPublisher(target: 'my-target', customData: ..., customDataTags: myTags)
+     * influxDbPublisher(selectedTarget: 'my-target', customData: ..., customDataTags: myTags)
      * }</pre>
      */
     private final Map<String, String> customDataTags;
@@ -102,7 +102,7 @@ public class InfluxDbPublicationService {
      * myFields2['field_d'] = 22
      * myCustomMeasurementFields['series_1'] = myFields1
      * myCustomMeasurementFields['series_2'] = myFields2
-     * influxDbPublisher(target: 'my-target', customDataMap: myCustomMeasurementFields)
+     * influxDbPublisher(selectedTarget: 'my-target', customDataMap: myCustomMeasurementFields)
      * }</pre>
      */
     private final Map<String, Map<String, Object>> customDataMap;
@@ -120,7 +120,7 @@ public class InfluxDbPublicationService {
      * myTags['buildResult'] = currentBuild.result
      * myTags['NODE_LABELS'] = env.NODE_LABELS
      * myCustomMeasurementTags['series_1'] = myTags
-     * influxDbPublisher(target: 'my-target', customDataMap: ..., customDataMapTags: myCustomMeasurementTags)
+     * influxDbPublisher(selectedTarget: 'my-target', customDataMap: ..., customDataMapTags: myCustomMeasurementTags)
      * }</pre>
      */
     private final Map<String, Map<String, String>> customDataMapTags;

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -178,6 +178,13 @@ public class InfluxDbPublicationService {
         JenkinsBasePointGenerator jGen = new JenkinsBasePointGenerator(build, listener, measurementRenderer, timestamp, jenkinsEnvParameterTag, jenkinsEnvParameterField, customPrefix, measurementName, env);
         addPoints(pointsToWrite, jGen, listener);
 
+        AgentPointGenerator agentGen = new AgentPointGenerator(build, listener, measurementRenderer, timestamp, jenkinsEnvParameterTag, customPrefix);
+        if (agentGen.hasReport()) {
+            addPoints(pointsToWrite, agentGen, listener);
+        } else {
+            logger.log(Level.FINE, "Data source empty: Agent Point");
+        }
+
         CustomDataPointGenerator cdGen = new CustomDataPointGenerator(build, listener, measurementRenderer, timestamp, jenkinsEnvParameterTag, customPrefix, customData, customDataTags, measurementName);
         if (cdGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Custom data found. Writing to InfluxDB...");

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -241,6 +241,18 @@ public class InfluxDbPublicationService {
             logger.log(Level.FINE, "Plugin skipped: Performance");
         }
 
+        try {
+            GitPointGenerator gitGen = new GitPointGenerator(build, listener, measurementRenderer, timestamp, jenkinsEnvParameterTag, customPrefix);
+            if (gitGen.hasReport()) {
+                listener.getLogger().println("[InfluxDB Plugin] Git data found. Writing to InfluxDB...");
+                addPoints(pointsToWrite, gitGen, listener);
+            } else {
+                logger.log(Level.FINE, "Plugin skipped: Git");
+            }
+        } catch (NoClassDefFoundError ignore) {
+            logger.log(Level.FINE, "Plugin skipped: Git");
+        }
+
         JUnitPointGenerator junitGen = new JUnitPointGenerator(build, listener, measurementRenderer, timestamp, jenkinsEnvParameterTag, customPrefix, env);
         if (junitGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] JUnit data found. Writing to InfluxDB...");

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublicationService.java
@@ -242,10 +242,9 @@ public class InfluxDbPublicationService {
             logger.log(Level.FINE, "Plugin skipped: JUnit");
         }
 
-        SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(build, listener, measurementRenderer, timestamp, jenkinsEnvParameterTag, customPrefix);
+        SonarQubePointGenerator sonarGen = new SonarQubePointGenerator(build, listener, measurementRenderer, timestamp, jenkinsEnvParameterTag, customPrefix, env);
         if (sonarGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] SonarQube data found. Writing to InfluxDB...");
-            sonarGen.setEnv(env);
             addPoints(pointsToWrite, sonarGen, listener);
         } else {
             logger.log(Level.FINE, "Plugin skipped: SonarQube");

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -44,8 +44,8 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep {
     private EnvVars env;
 
     @DataBoundConstructor
-    public InfluxDbPublisher(String target) {
-        this.selectedTarget = target;
+    public InfluxDbPublisher(String selectedTarget) {
+        this.selectedTarget = selectedTarget;
     }
 
     public String getSelectedTarget() {
@@ -188,7 +188,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
+    public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath workspace, @Nonnull EnvVars envVars, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
             throws InterruptedException, IOException {
 
         // Gets the target from the job's config
@@ -202,7 +202,8 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep {
 
         measurementName = getMeasurementNameIfNotBlankOrDefault();
         if (env == null) {
-            env = build.getEnvironment(listener);
+//            env = build.getEnvironment(listener);
+            env = envVars;
         }
 
         String expandedCustomPrefix = env.expand(customPrefix);

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbStepExecution.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbStepExecution.java
@@ -34,7 +34,7 @@ public class InfluxDbStepExecution extends SynchronousNonBlockingStepExecution<V
         publisher.setMeasurementName(step.getMeasurementName());
         publisher.setEnv(getContext().get(EnvVars.class));
 
-        publisher.perform(getContext().get(Run.class), workspace, getContext().get(Launcher.class), getContext().get(TaskListener.class));
+        publisher.perform(getContext().get(Run.class), workspace, getContext().get(EnvVars.class), getContext().get(Launcher.class), getContext().get(TaskListener.class));
         return null;
     }
 }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
@@ -8,7 +8,7 @@ import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.commons.text.StringSubstitutor;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -107,7 +107,7 @@ public abstract class AbstractPointGenerator implements PointGenerator {
     private String resolveEnvParameter(String stringValue) {
         try {
             EnvVars envVars = build.getEnvironment(listener);
-            return StrSubstitutor.replace(stringValue, envVars);
+            return StringSubstitutor.replace(stringValue, envVars);
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/AbstractPointGenerator.java
@@ -19,8 +19,10 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractPointGenerator implements PointGenerator {
 
+    public static final String PROJECT_NAMESPACE = "project_namespace";
     public static final String PROJECT_NAME = "project_name";
     public static final String PROJECT_PATH = "project_path";
+    public static final String INSTANCE = "instance";
     public static final String BUILD_NUMBER = "build_number";
     public static final String CUSTOM_PREFIX = "prefix";
 
@@ -41,8 +43,9 @@ public abstract class AbstractPointGenerator implements PointGenerator {
 
     @Override
     public Point buildPoint(String name, String customPrefix, Run<?, ?> build, long timestamp) {
+        Jenkins instance = Jenkins.getInstanceOrNull();
         String projectName = projectNameRenderer.render(build);
-        String projectPath = build.getParent().getRelativeNameFrom(Jenkins.getInstanceOrNull());
+        String projectPath = build.getParent().getRelativeNameFrom(instance);
 
         Point point = Point
                 .measurement(name)
@@ -57,6 +60,8 @@ public abstract class AbstractPointGenerator implements PointGenerator {
 
         point.addTag(PROJECT_NAME, projectName);
         point.addTag(PROJECT_PATH, projectPath);
+        point.addTag(INSTANCE, instance != null ? instance.getRootUrl() : "");
+        point.addTag(PROJECT_NAMESPACE, projectPath.split("/")[0]);
 
 
         if (StringUtils.isNotBlank(jenkinsEnvParameterTag)) {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/AgentPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/AgentPointGenerator.java
@@ -1,0 +1,131 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+
+import com.influxdb.client.write.Point;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Node;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.labels.LabelAtom;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+
+/**
+ * @author Mathieu Delrocq
+ */
+public class AgentPointGenerator extends AbstractPointGenerator {
+
+    protected static final String AGENT_NAME = "agent_name";
+    protected static final String AGENT_LABEL = "agent_label";
+    protected static final String UNIQUE_ID = "unique_id"; 
+
+    private List<Map.Entry<String, String>> agentPoints;
+    private String customPrefix;
+
+    public AgentPointGenerator(Run<?, ?> build, TaskListener listener, ProjectNameRenderer projectNameRenderer,
+            long timestamp, String jenkinsEnvParameterTag, String customPrefix) {
+        super(build, listener, projectNameRenderer, timestamp, jenkinsEnvParameterTag);
+        this.agentPoints = getAgentPoints(build);
+        this.customPrefix = customPrefix;
+    }
+
+    @Override
+    public boolean hasReport() {
+        return CollectionUtils.isNotEmpty(agentPoints);
+    }
+
+    @Override
+    public Point[] generate() {
+        List<Point> points = new ArrayList<>();
+        Map.Entry<String, String> agentPoint = null;
+        for (int i = 0; i < agentPoints.size(); i++) {
+            agentPoint = agentPoints.get(i);
+            Point point = buildPoint("agent_data", customPrefix, build)//
+                    .addTag(UNIQUE_ID, String.valueOf(i+1))//
+                    .addField(AGENT_NAME, agentPoint.getKey())//
+                    .addField(AGENT_LABEL, agentPoint.getValue());
+            points.add(point);
+        }
+        return points.toArray(new Point[0]);
+    }
+
+    public String getFirstAgent() {
+        return !CollectionUtils.isEmpty(agentPoints) ? agentPoints.get(0).getKey() : "";
+    }
+
+    /**
+     * Retrieve agent(s) used by the build and return {@link AgentPoint}
+     * 
+     * @param build
+     * @return list of {@link AgentPoint}
+     */
+    private List<Map.Entry<String, String>> getAgentPoints(Run<?, ?> build) {
+        if (build instanceof AbstractBuild) {
+            return getAgentFromAbstractBuild((AbstractBuild<?, ?>) build);
+        } else if (build instanceof FlowExecutionOwner.Executable) {
+            return getAgentsFromPipeline((FlowExecutionOwner.Executable) build);
+        }
+        return new ArrayList<>();
+    }
+
+    /**
+     * Retrieve agent(s) for traditional jobs
+     * 
+     * @param build
+     * @return list of {@link AgentPoint}
+     */
+    private List<Map.Entry<String, String>> getAgentFromAbstractBuild(AbstractBuild<?, ?> build) {
+        List<Map.Entry<String, String>> agentPointsList = new ArrayList<>();
+        Node node = build.getBuiltOn();
+        if (node != null) {
+            agentPointsList
+                    .add(new AbstractMap.SimpleEntry<String, String>(node.getDisplayName(), node.getLabelString()));
+        }
+        return agentPointsList;
+    }
+
+    /**
+     * Retrieve agent(s) for pipeline jobs
+     * 
+     * @param build
+     * @return list of {@link AgentPoint}
+     */
+    private List<Map.Entry<String, String>> getAgentsFromPipeline(FlowExecutionOwner.Executable build) {
+        List<Map.Entry<String, String>> agentPointsList = new ArrayList<>();
+        FlowExecutionOwner flowExecutionOwner = build.asFlowExecutionOwner();
+        if (flowExecutionOwner != null) {
+            FlowExecution flowExecution = flowExecutionOwner.getOrNull();
+            if (flowExecution != null) {
+                FlowGraphWalker graphWalker = new FlowGraphWalker(flowExecution);
+                for (FlowNode flowNode : graphWalker) {
+                    WorkspaceAction workspaceAction = flowNode.getAction(WorkspaceAction.class);
+                    if (null != workspaceAction) {
+                        Set<LabelAtom> labels = workspaceAction.getLabels();
+                        StringJoiner labelString = new StringJoiner(", ");
+                        labelString.setEmptyValue("");
+                        for (LabelAtom label : labels) {
+                            labelString.add(label.getName());
+                        }
+                        String nodeName = workspaceAction.getNode();
+                        agentPointsList
+                                .add(new AbstractMap.SimpleEntry<String, String>(nodeName, labelString.toString()));
+                    }
+                }
+            }
+        }
+        return agentPointsList;
+    }
+}

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/GitPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/GitPointGenerator.java
@@ -1,0 +1,80 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import com.influxdb.client.write.Point;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.Revision;
+import hudson.plugins.git.util.BuildData;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+
+/**
+ * @author Mathieu Delrocq
+ */
+public class GitPointGenerator extends AbstractPointGenerator {
+
+    // Point fields names
+    protected static final String GIT_REPOSITORY = "git_repository";
+    protected static final String GIT_REVISION = "git_revision";
+    protected static final String GIT_REFERENCE = "git_reference";
+    protected static final String UNIQUE_ID = "unique_id";
+
+    private String customPrefix;
+    private List<BuildData> gitActions;
+
+    public GitPointGenerator(Run<?, ?> build, TaskListener listener, ProjectNameRenderer projectNameRenderer,
+            long timestamp, String jenkinsEnvParameterTag, String customPrefix) {
+        super(build, listener, projectNameRenderer, timestamp, jenkinsEnvParameterTag);
+        this.customPrefix = customPrefix;
+        gitActions = build.getActions(BuildData.class);
+    }
+
+    /**
+     * Check if git infos are presents in the build
+     * 
+     * @return true if present
+     */
+    @Override
+    public boolean hasReport() {
+        return CollectionUtils.isNotEmpty(gitActions);
+    }
+
+    /**
+     * Generates Git Points with datas in Git plugins
+     * 
+     * return Array of Point
+     */
+    @Override
+    public Point[] generate() {
+        List<Point> points = new ArrayList<>();
+        String sha1String = null;
+        String branchName = null;
+        BuildData gitAction = null;
+        for (int i = 0; i < gitActions.size(); i++) {
+            gitAction = gitActions.get(i);
+            Revision revision = gitAction.getLastBuiltRevision();
+            if(revision != null) {
+                sha1String = revision.getSha1String();
+                Collection<Branch> branches = revision.getBranches();
+                if (CollectionUtils.isNotEmpty(branches)) {
+                    branchName = branches.iterator().next().getName();
+                }
+            }
+            Point point = buildPoint("git_data", customPrefix, build)
+                    .addTag(UNIQUE_ID, String.valueOf(i+1))
+                    .addField(GIT_REPOSITORY, !CollectionUtils.isEmpty(gitAction.getRemoteUrls()) ? gitAction.getRemoteUrls().iterator().next() : "")//
+                    .addField(GIT_REFERENCE, branchName)
+                    .addField(GIT_REVISION, sha1String);
+            points.add(point);
+        }
+        return points.toArray(new Point[0]);
+    }
+
+}

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JUnitPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JUnitPointGenerator.java
@@ -22,6 +22,7 @@ public class JUnitPointGenerator extends AbstractPointGenerator{
     private static final String JUNIT_TEST_STATUS = "test_status";
     private static final String JUNIT_TEST_STATUS_ORDINAL = "test_status_ordinal";
     private static final String JUNIT_DURATION = "test_duration";
+    private static final String JUNIT_COUNT = "test_count";
 
     private final String customPrefix;
     private final TaskListener listener;
@@ -63,6 +64,7 @@ public class JUnitPointGenerator extends AbstractPointGenerator{
                     .addField(JUNIT_TEST_STATUS, caseResult.getStatus().toString())
                     .addField(JUNIT_TEST_STATUS_ORDINAL, caseResult.getStatus().ordinal())
                     .addField(JUNIT_DURATION, caseResult.getDuration())
+                    .addField(JUNIT_COUNT, 1L)
                     .addTag(JUNIT_SUITE_NAME, caseResult.getSuiteResult().getName())
                     .addTag(JUNIT_TEST_NAME, caseResult.getName())
                     .addTag(JUNIT_TEST_CLASS_FULL_NAME, caseResult.getClassName())

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JacocoPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JacocoPointGenerator.java
@@ -33,6 +33,7 @@ public class JacocoPointGenerator extends AbstractPointGenerator {
     }
 
     public Point[] generate() {
+        
         Point point = buildPoint("jacoco_data", customPrefix, build);
         addFields(point, JACOCO_CLASS, jacocoBuildAction.getResult().getClassCoverage());
         addFields(point, JACOCO_LINE, jacocoBuildAction.getResult().getLineCoverage());

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -124,7 +124,25 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
         }
 
         if (hasMetricsPlugin(build)) {
+            java.util.logging.Logger LOGGER = java.util.logging.Logger.getLogger(this.getClass().getName());
+
             point.addField(TIME_IN_QUEUE, build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getQueuingDurationMillis());
+            point.addField(TOTAL_TIME_IN_QUEUE, build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getQueuingTimeMillis());
+            point.addField(NUM_SUBTASKS, build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getSubTaskCount());
+
+            // Subtask Point Generator -- Used to check longest subtask wait time
+            int subtask_count = 0;
+            for (Map.Entry<String, Long> subtask :
+                build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getSubTaskMap().entrySet()) {
+
+                if (subtask_count > MAX_SUBTASKS) {
+                    LOGGER.log(Level.WARNING, "Too many subtasks");
+                    break;
+                }
+
+                point.addField(subtask.getKey(), subtask.getValue());
+                subtask_count++;
+            }
         }
 
         if (StringUtils.isNotBlank(jenkinsEnvParameterField)) {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -18,6 +18,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.StringJoiner;
 
+import java.util.Objects;
+
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
 public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
     public static final String BUILD_TIME = "build_time";
@@ -53,6 +58,11 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
     public static final String AGENT_LOG_PATTERN = "Running on ";
 
+    public static final String SUMMED_TIME_IN_QUEUE = "summed_time_in_queue";
+    public static final String NUM_SUBTASKS = "num_subtasks";
+
+    public static final Integer MAX_SUBTASKS = 50;
+
     private final Run<?, ?> build;
     private final String customPrefix;
     private final String jenkinsEnvParameterField;
@@ -73,7 +83,6 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
         this.measurementName = measurementName;
         this.env = env;
         this.projectNameRenderer = Objects.requireNonNull(projectNameRenderer);
-
     }
 
     public boolean hasReport() {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -58,6 +58,7 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     private final String jenkinsEnvParameterField;
     private final String measurementName;
     private EnvVars env;
+    private final ProjectNameRenderer projectNameRenderer;
 
 
     // (Run<?, ?> build, TaskListener listener, MeasurementRenderer projectNameRenderer, long timestamp, String jenkinsEnvParameterTag) {
@@ -71,6 +72,8 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
         this.jenkinsEnvParameterField = jenkinsEnvParameterField;
         this.measurementName = measurementName;
         this.env = env;
+        this.projectNameRenderer = Objects.requireNonNull(projectNameRenderer);
+
     }
 
     public boolean hasReport() {
@@ -127,7 +130,7 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
             java.util.logging.Logger LOGGER = java.util.logging.Logger.getLogger(this.getClass().getName());
 
             point.addField(TIME_IN_QUEUE, build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getQueuingDurationMillis());
-            point.addField(TOTAL_TIME_IN_QUEUE, build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getQueuingTimeMillis());
+            point.addField(SUMMED_TIME_IN_QUEUE, build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getQueuingTimeMillis());
             point.addField(NUM_SUBTASKS, build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getSubTaskCount());
 
             // Subtask Point Generator -- Used to check longest subtask wait time
@@ -136,7 +139,10 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
                 build.getAction(jenkins.metrics.impl.TimeInQueueAction.class).getSubTaskMap().entrySet()) {
 
                 if (subtask_count > MAX_SUBTASKS) {
-                    LOGGER.log(Level.WARNING, "Too many subtasks");
+                    String projectName = projectNameRenderer.render(build);
+                    String buildNumber = build.getDisplayName();
+                    LOGGER.log(Level.WARNING, "Job " + projectName + " build number " + buildNumber +
+                        " generated too many subtasks -- Number of subtasks exceeded MAX_SUBTASKS threshold of 50");
                     break;
                 }
 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -17,8 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.StringJoiner;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
@@ -203,7 +201,7 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
     /**
      * Retrieve agent name in the log of the build
-     * 
+     *
      * @return agent name
      */
     private String getNodeNameFromLogs() {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -6,13 +6,19 @@ import hudson.model.Cause;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.model.Cause.UserIdCause;
 import hudson.tasks.test.AbstractTestResultAction;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.StringJoiner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class JenkinsBasePointGenerator extends AbstractPointGenerator {
 
@@ -37,6 +43,8 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     public static final String BUILD_AGENT_NAME = "build_agent_name";
     public static final String BUILD_BRANCH_NAME = "build_branch_name";
     public static final String BUILD_CAUSER = "build_causer";
+    public static final String BUILD_USER = "build_user";
+    public static final String BUILD_CAUSE = "build_cause";
 
     public static final String PROJECT_BUILD_HEALTH = "project_build_health";
     public static final String PROJECT_LAST_SUCCESSFUL = "last_successful_build";
@@ -44,6 +52,8 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     public static final String TESTS_FAILED = "tests_failed";
     public static final String TESTS_SKIPPED = "tests_skipped";
     public static final String TESTS_TOTAL = "tests_total";
+
+    public static final String AGENT_LOG_PATTERN = "Running on ";
 
     private final Run<?, ?> build;
     private final String customPrefix;
@@ -87,6 +97,8 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
             ordinal = buildResult.ordinal;
         }
 
+        String[] buildCause = getCauseDatas();
+
         Point point = buildPoint(measurementName, customPrefix, build);
 
         point.addField(BUILD_TIME, build.getDuration() == 0 ? dt : build.getDuration())
@@ -97,12 +109,14 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
             .addField(BUILD_RESULT, result)
             .addField(BUILD_RESULT_ORDINAL, ordinal)
             .addField(BUILD_IS_SUCCESSFUL, ordinal < 2)
-            .addField(BUILD_AGENT_NAME, getBuildEnv("NODE_NAME"))
+            .addField(BUILD_AGENT_NAME, getNodeName())
             .addField(BUILD_BRANCH_NAME, getBuildEnv("BRANCH_NAME"))
             .addField(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())
             .addField(PROJECT_LAST_SUCCESSFUL, getLastSuccessfulBuild())
             .addField(PROJECT_LAST_STABLE, getLastStableBuild())
             .addField(BUILD_CAUSER , getCauseShortDescription())
+            .addField(BUILD_USER, buildCause[0])
+            .addField(BUILD_CAUSE, buildCause[1])
             .addTag(BUILD_RESULT, result);
 
         if (hasTestResults(build)) {
@@ -151,6 +165,24 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
         }
     }
 
+    private String[] getCauseDatas() {
+        String userCause = "";
+        StringJoiner triggers = new StringJoiner(", ");
+        try {
+            for (Cause cause : build.getCauses()) {
+                triggers.add(cause.getClass().getSimpleName());
+                if (cause instanceof UserIdCause) {
+                    userCause = ((UserIdCause) cause).getUserId();
+                } else if (cause.getClass().getName().contains("GitlabWebhookCause")) {
+                    userCause = build.getEnvironment(listener).get("gitlabUserUsername");
+                }
+            }
+            return new String[] { userCause != null ? userCause : "", triggers.toString() };
+        } catch (IOException | InterruptedException e) {
+            return new String[] { "", "" };
+        }
+    }
+
     private int getLastSuccessfulBuild() {
         Run<?, ?> lastSuccessfulBuild = build.getParent().getLastSuccessfulBuild();
         return lastSuccessfulBuild != null ? lastSuccessfulBuild.getNumber() : 0;
@@ -159,5 +191,34 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
     private int getLastStableBuild() {
         Run<?, ?> lastStableBuild = build.getParent().getLastStableBuild();
         return lastStableBuild != null ? lastStableBuild.getNumber() : 0;
+    }
+
+    private String getNodeName() {
+        String nodeName = getBuildEnv("NODE_NAME");
+        if(StringUtils.isEmpty(nodeName)) {
+            nodeName = getNodeNameFromLogs();
+        }
+        return nodeName;
+    }
+
+    /**
+     * Retrieve agent name in the log of the build
+     * 
+     * @return agent name
+     */
+    private String getNodeNameFromLogs() {
+        String agentName = "";
+        try (BufferedReader br = new BufferedReader(build.getLogReader())) {
+            String line;
+            String[] splitLine;
+            while ((line = br.readLine()) != null) {
+                if (line.startsWith(AGENT_LOG_PATTERN)) {
+                    splitLine = line.split(" ");
+                    agentName = splitLine.length >= 3 ? splitLine[2] : "";
+                    break;
+                }
+            }
+        } catch (IOException e) {}
+        return agentName;
     }
 }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/MetricsPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/MetricsPointGenerator.java
@@ -1,0 +1,52 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import com.influxdb.client.write.Point;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.metrics.impl.TimeInQueueAction;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+
+public class MetricsPointGenerator extends AbstractPointGenerator {
+    private static final String BLOCKED_TIME = "blocked_time";
+    private static final String BUILDABLE_TIME = "buildable_time";
+    private static final String BUILDING_TIME = "building_time";
+    private static final String EXECUTING_TIME = "executing_time";
+    private static final String EXECUTOR_UTILIZATION = "executor_utilization";
+    private static final String QUEUEING_TIME = "queue_time";
+    private static final String SUBTASK_COUNT = "subtask_count";
+    private static final String TOTAL_DURATION = "total_duration";
+    private static final String WAITING_TIME = "waiting_time";
+
+    private final Run<?, ?> build;
+    private final String customPrefix;
+    private final TimeInQueueAction timeInQueueAction;
+
+    public MetricsPointGenerator(Run<?, ?> build, TaskListener listener,
+                                        ProjectNameRenderer projectNameRenderer,
+                                        long timestamp, String jenkinsEnvParameterTag,
+                                        String customPrefix) {
+        super(build, listener, projectNameRenderer, timestamp, jenkinsEnvParameterTag);
+        this.build = build;
+        this.customPrefix = customPrefix;
+        timeInQueueAction = build.getAction(TimeInQueueAction.class);
+    }
+
+    public boolean hasReport() {
+        return timeInQueueAction != null;
+    }
+
+    public Point[] generate() {
+        Point point = buildPoint("metrics_data", customPrefix, build);
+        point.addField(BLOCKED_TIME, timeInQueueAction.getBlockedDurationMillis());
+        point.addField(BUILDABLE_TIME, timeInQueueAction.getBuildableDurationMillis());
+        point.addField(BUILDING_TIME, timeInQueueAction.getBuildingDurationMillis());
+        point.addField(EXECUTING_TIME, timeInQueueAction.getExecutingTimeMillis());
+        point.addField(EXECUTOR_UTILIZATION, timeInQueueAction.getExecutorUtilization());
+        point.addField(QUEUEING_TIME, timeInQueueAction.getQueuingDurationMillis());
+        point.addField(SUBTASK_COUNT, timeInQueueAction.getSubTaskCount());
+        point.addField(TOTAL_DURATION, timeInQueueAction.getTotalDurationMillis());
+        point.addField(WAITING_TIME, timeInQueueAction.getWaitingDurationMillis());
+        return new Point[] {point};
+    }
+}

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/RobotFrameworkPointGenerator.java
@@ -145,8 +145,8 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
         private int failed = 0;
         private int passed = 0;
         private int skipped = 0;
-        private int criticalFailed = 0;
-        private int criticalPassed = 0;
+        private long criticalFailed = 0;
+        private long criticalPassed = 0;
         private long duration = 0;
 
         private RobotTagResult(String name) {
@@ -174,9 +174,9 @@ public class RobotFrameworkPointGenerator extends AbstractPointGenerator {
         return buildPoint("tag_point", customPrefix, build, timestamp)
             .addTag(RF_TAG_NAME, tagResult.name)
             .addField(RF_TAG_NAME, tagResult.name)
-            .addField(RF_CRITICAL_FAILED, tagResult.criticalFailed)
-            .addField(RF_CRITICAL_PASSED, tagResult.criticalPassed)
-            .addField(RF_CRITICAL_TOTAL, tagResult.criticalPassed + tagResult.criticalFailed)
+            .addField(RF_CRITICAL_FAILED, (int)tagResult.criticalFailed)    // Send data as int for backwards compatibility
+            .addField(RF_CRITICAL_PASSED, (int)tagResult.criticalPassed)    // Send data as int for backwards compatibility
+            .addField(RF_CRITICAL_TOTAL, (int)(tagResult.criticalPassed + tagResult.criticalFailed))    // Send data as int for backwards compatibility
             .addField(RF_FAILED, tagResult.failed)
             .addField(RF_PASSED, tagResult.passed)
             .addField(RF_SKIPPED, tagResult.skipped)

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -1,10 +1,7 @@
 package jenkinsci.plugins.influxdb.generators;
 
-import java.io.BufferedReader;
-import java.io.IOException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.io.InputStreamReader;
-import java.io.FileInputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -114,7 +111,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
             sonarBuildTaskIdUrl = result[3];
             
             return !StringUtils.isEmpty(sonarBuildURL);
-        } catch (IOException | IndexOutOfBoundsException ignored) {}
+        } catch (IOException | IndexOutOfBoundsException | UncheckedIOException ignored) {}
 
         return false;
     }
@@ -248,16 +245,16 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
         }
     }
 
-    private String[] getSonarProjectFromBuildReport() throws IOException {    
+    private String[] getSonarProjectFromBuildReport() throws IOException, UncheckedIOException {
         String projName = null;
         String url = null;
         String taskId = null;
         String taskUrl = null;
 
-        String workspaceDir = env.get("WORKSPACE", "");
-        List<Path> reportsPaths = this.findReportByFileName(workspaceDir);
+        String workspaceDir = env.get("WORKSPACE");
+        List<Path> reportsPaths = workspaceDir == null ? null : this.findReportByFileName(workspaceDir);
         
-        if (reportsPaths.size() != 1) {
+        if (reportsPaths == null || reportsPaths.size() != 1) {
             return new String[]{null, null, null, null};
         }
         String reportFilePath = reportsPaths.get(0).toFile().getPath();
@@ -302,7 +299,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     }
 
     public List<Path> findReportByFileName(String workspacePath)
-            throws IOException {
+            throws IOException, UncheckedIOException {
 
         Path path = Paths.get(workspacePath);                
         String reportName = env.get("SONARQUBE_BUILD_REPORT_NAME", 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -69,7 +69,13 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
             + "(.*)";
     private static final String URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS = ".*" + Pattern.quote("QUALITY GATE STATUS: ") 
             + "(.*)" + Pattern.quote(" - View details on ") + "(.*)";
+    private static final String URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS_v4_8 = ".*" + Pattern.quote("ANALYSIS SUCCESSFUL, you can find the results at: ") 
+            + "(.*)";
+    private static final String URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS_TIMEOUT = ".*" + Pattern.quote("Quality Gate check timeout exceeded - View details on ") 
+            + "(.*)";
 
+
+            
     private String projectKey = null;
     private String sonarBuildURL = null;
     private String sonarBuildTaskIdUrl = null;
@@ -284,6 +290,9 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
             Matcher match;
             Pattern p_analysis_url = Pattern.compile(URL_PATTERN_IN_LOGS_ANALYSIS);
             Pattern p_qg_url = Pattern.compile(URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS);
+            Pattern p_qg_url_timeout = Pattern.compile(URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS_TIMEOUT);
+            Pattern p_qg_url_v4_8 = Pattern.compile(URL_PATTERN_IN_LOGS_QUALITY_GATE_STATUS_v4_8);
+        
             Pattern p_taskUrl = Pattern.compile(TASK_URL_PATTERN_IN_LOGS);
             Pattern p_projName = Pattern.compile(PROJECT_NAME_PATTERN_IN_LOGS);
 
@@ -296,6 +305,18 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
                 match = p_qg_url.matcher(line);
                 if (match.matches()) {
                     url  = match.group(2);
+                    //Task already executed.  No need to search for other lines
+                    break; 
+                }
+                match = p_qg_url_v4_8.matcher(line);
+                if (match.matches()) {
+                    url  = match.group(1);
+                    //Task already executed.  No need to search for other lines
+                    break; 
+                }
+                match = p_qg_url_timeout.matcher(line);
+                if (match.matches()) {
+                    url  = match.group(1);
                     //Task already executed.  No need to search for other lines
                     break; 
                 }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGenerator.java
@@ -48,6 +48,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
     private static final String SONARQUBE_LINE_COVERAGE = "line_coverage";
     private static final String SONARQUBE_LINES_TO_COVER = "lines_to_cover";
     private static final String SONARQUBE_ALERT_STATUS = "alert_status"; // Quality Gate Status
+    private static final String SONARQUBE_QUALITY_GATE_DETAILS = "quality_gate_details";
     private static final String SONARQUBE_DUPLICATED_LINES_DENSITY = "duplicated_lines_density";
     private static final String SONARQUBE_TECHNICAL_DEBT = "sqale_index";
     private static final String SONARQUBE_TECHNICAL_DEBT_RATIO = "sqale_debt_ratio";
@@ -220,6 +221,7 @@ public class SonarQubePointGenerator extends AbstractPointGenerator {
                     .addField(SONARQUBE_DUPLICATED_LINES_DENSITY, getSonarMetric(sonarMetricsUrl, SONARQUBE_DUPLICATED_LINES_DENSITY))
                     .addField(SONARQUBE_COMPLEXITY, getSonarMetric(sonarMetricsUrl, SONARQUBE_COMPLEXITY))
                     .addField(SONARQUBE_ALERT_STATUS, getSonarMetricStr(sonarMetricsUrl, SONARQUBE_ALERT_STATUS))
+                    .addField(SONARQUBE_QUALITY_GATE_DETAILS, getSonarMetricStr(sonarMetricsUrl, SONARQUBE_QUALITY_GATE_DETAILS))
                     .addField(SONARQUBE_TECHNICAL_DEBT, getSonarMetric(sonarMetricsUrl, SONARQUBE_TECHNICAL_DEBT))
                     .addField(SONARQUBE_TECHNICAL_DEBT_RATIO, getSonarMetric(sonarMetricsUrl, SONARQUBE_TECHNICAL_DEBT_RATIO));
         } catch (IOException e) {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityJsonSummaryFile.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityJsonSummaryFile.java
@@ -17,10 +17,17 @@ public class SerenityJsonSummaryFile implements ISerenityJsonSummaryFile {
     }
 
     public boolean exists() {
-        return Files.exists(getPath());
+        try {
+            return Files.exists(getPath());
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     public Path getPath() {
+        if (workspace == null) {
+            throw new IllegalArgumentException("no workspace");
+        }
         return java.nio.file.Paths.get(workspace, SERENITY_OUTPUT_DIRECTORY, SERENITY_JSON_SUMMARY_FILE);
     }
 

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityPointGenerator.java
@@ -67,7 +67,7 @@ public class SerenityPointGenerator extends AbstractPointGenerator {
     }
 
     public boolean hasReport() {
-        return (serenityJsonSummaryFile.exists());
+        return (serenityJsonSummaryFile != null && serenityJsonSummaryFile.exists());
     }
 
     public Point[] generate() {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityPointGenerator.java
@@ -67,7 +67,7 @@ public class SerenityPointGenerator extends AbstractPointGenerator {
     }
 
     public boolean hasReport() {
-        return (serenityJsonSummaryFile != null && serenityJsonSummaryFile.exists());
+        return serenityJsonSummaryFile.exists();
     }
 
     public Point[] generate() {

--- a/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
@@ -2,7 +2,6 @@ package jenkinsci.plugins.influxdb.models;
 
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import hudson.Extension;

--- a/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
@@ -9,8 +9,6 @@ import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.InfluxDBClientOptions;
-import com.influxdb.client.domain.Bucket;
-import com.influxdb.client.domain.User;
 import com.influxdb.exceptions.InfluxException;
 
 import hudson.Extension;
@@ -26,8 +24,6 @@ import java.util.List;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -200,7 +196,7 @@ public class Target extends AbstractDescribableImpl<Target> implements java.io.S
         public FormValidation doCheckDatabase(@QueryParameter String value) {
             return FormValidation.validateRequired(value);
         }
-        
+
         @POST
         public FormValidation doVerifyConnection(@QueryParameter String url, @QueryParameter String credentialsId,
                                                  @QueryParameter String organization, @QueryParameter String database,

--- a/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
@@ -1,5 +1,6 @@
 package jenkinsci.plugins.influxdb.models;
 
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
@@ -157,11 +158,15 @@ public class Target extends AbstractDescribableImpl<Target> implements java.io.S
             if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return new StandardListBoxModel().includeCurrentValue(credentialsId);
             }
-            return new StandardUsernameListBoxModel()
+            return new StandardListBoxModel()
                     .includeEmptyValue()
                     .includeAs(ACL.SYSTEM,
                             Jenkins.get(),
                             StandardUsernamePasswordCredentials.class,
+                            URIRequirementBuilder.fromUri(url).build())
+                    .includeAs(ACL.SYSTEM,
+                            Jenkins.get(),
+                            StandardCredentials.class,
                             URIRequirementBuilder.fromUri(url).build())
                     .includeCurrentValue(credentialsId);
         }

--- a/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/models/Target.java
@@ -1,19 +1,38 @@
 package jenkinsci.plugins.influxdb.models;
 
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.InfluxDBClientFactory;
+import com.influxdb.client.InfluxDBClientOptions;
+import com.influxdb.client.domain.Bucket;
+import com.influxdb.client.domain.User;
+import com.influxdb.exceptions.InfluxException;
+
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
+
+import java.util.List;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.verb.POST;
+import org.springframework.security.access.AccessDeniedException;
 
 public class Target extends AbstractDescribableImpl<Target> implements java.io.Serializable {
 
@@ -180,6 +199,64 @@ public class Target extends AbstractDescribableImpl<Target> implements java.io.S
 
         public FormValidation doCheckDatabase(@QueryParameter String value) {
             return FormValidation.validateRequired(value);
+        }
+        
+        @POST
+        public FormValidation doVerifyConnection(@QueryParameter String url, @QueryParameter String credentialsId,
+                                                 @QueryParameter String organization, @QueryParameter String database,
+                                                 @QueryParameter String retentionPolicy, @AncestorInPath Item context) {
+            InfluxDBClient influxDB = null;
+            doCheckUrl(url);
+            doCheckDatabase(database);
+            try {
+                Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+
+                List<StandardUsernamePasswordCredentials> lookupCredentials = CredentialsProvider.lookupCredentials(
+                        StandardUsernamePasswordCredentials.class,
+                        context,
+                        ACL.SYSTEM,
+                        URIRequirementBuilder.fromUri(url).build());
+
+                StandardUsernamePasswordCredentials credentials = CredentialsMatchers.firstOrNull(lookupCredentials, CredentialsMatchers.withId(null == credentialsId ? "" : credentialsId));
+
+                if (organization != null && !organization.trim().isEmpty()) {
+                    InfluxDBClientOptions.Builder options = InfluxDBClientOptions.builder().url(url).org(organization).bucket(database);
+
+                    if (credentials != null) { // basic auth
+                        options.authenticate(credentials.getUsername(), credentials.getPassword().getPlainText().toCharArray());
+                    } else { // token auth
+                        List<StringCredentials> lookupTokenCredentials = CredentialsProvider.lookupCredentials(//
+                                StringCredentials.class,
+                                context,
+                                ACL.SYSTEM,
+                                URIRequirementBuilder.fromUri(url).build());
+                        StringCredentials c = CredentialsMatchers.firstOrNull(lookupTokenCredentials, CredentialsMatchers.withId(null == credentialsId ? "" : credentialsId));
+                        assert c != null;
+                        options.authenticateToken(c.getSecret().getPlainText().toCharArray());
+                    }
+
+                    influxDB = InfluxDBClientFactory.create(options.build());
+
+                } else {
+                    influxDB = credentials == null
+                            ? InfluxDBClientFactory.createV1(url, "", "".toCharArray(), database, retentionPolicy)
+                            : InfluxDBClientFactory.createV1(url, credentials.getUsername(),
+                                    credentials.getPassword().getPlainText().toCharArray(), database, retentionPolicy);
+                }
+
+                boolean connected = influxDB.ping();
+                if(connected) {
+                    return FormValidation.ok("Connection success");
+                } else {
+                    return FormValidation.ok("Connection Failed");
+                }
+            } catch (InfluxException | AccessDeniedException e) {
+                return FormValidation.error(e, "Connection Failed");
+            } finally {
+                if (influxDB != null) {
+                    influxDB.close();
+                }
+            }
         }
     }
 }

--- a/src/main/resources/jenkinsci/plugins/influxdb/models/Target/config.jelly
+++ b/src/main/resources/jenkinsci/plugins/influxdb/models/Target/config.jelly
@@ -18,6 +18,8 @@
     </f:entry>
     <f:entry title="Retention Policy" field="retentionPolicy">
         <f:textbox default="autogen"/>
+    <f:validateButton title="Test Connection" progress="Testing..." method="verifyConnection"
+        with="url,credentialsId,organization,database,retentionPolicy"/>
     </f:entry>
     <f:entry title="Job scheduled time as timestamp" field="jobScheduledTimeAsPointsTimestamp">
         <f:checkbox default="false"/>

--- a/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
@@ -1,5 +1,6 @@
 package jenkinsci.plugins.influxdb;
 
+import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.FreeStyleProject;
@@ -36,6 +37,8 @@ public class InfluxDbPublisherTest {
     private Launcher launcher;
     @Mock
     private TaskListener listener;
+    @Mock
+    private EnvVars envVars;
 
     @Test
     public void testEmptyTargetShouldThrowException() throws Exception {
@@ -48,7 +51,7 @@ public class InfluxDbPublisherTest {
         Mockito.when(jenkinsMock.getDescriptorByType(InfluxDbPublisher.DescriptorImpl.class)).thenReturn(descriptorMock);
 
         try {
-            new InfluxDbPublisher("").perform(build, workspace, launcher, listener);
+            new InfluxDbPublisher("").perform(build, workspace, envVars, launcher, listener);
         } catch (NullPointerException e) {
             Assert.fail("NullPointerException raised");
         }

--- a/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
@@ -71,10 +71,9 @@ public class InfluxDbPublisherTest {
         InfluxDbPublisher before = new InfluxDbPublisher("Target2");
         assertEquals(before.getSelectedTarget(), "Target2");
         assertEquals(before.getTarget(), target2);
-
         FreeStyleProject project = j.createFreeStyleProject();
         project.getPublishersList().add(before);
-        j.submit(j.createWebClient().getPage(project,"configure").getFormByName("config"));
+        j.configRoundtrip(project);
 
         InfluxDbPublisher after = project.getPublishersList().get(InfluxDbPublisher.class);
         j.assertEqualBeans(before, after, "selectedTarget");

--- a/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/InfluxDbPublisherTest.java
@@ -8,10 +8,8 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
 import jenkinsci.plugins.influxdb.models.Target;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mock;
@@ -21,14 +19,12 @@ import java.io.File;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class InfluxDbPublisherTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     private FilePath workspace = new FilePath(new File("."));
     @Mock
@@ -41,20 +37,14 @@ public class InfluxDbPublisherTest {
     private EnvVars envVars;
 
     @Test
-    public void testEmptyTargetShouldThrowException() throws Exception {
-        exception.expect(RuntimeException.class);
-        exception.expectMessage("Target was null!");
+    public void testEmptyTargetShouldThrowException() {
 
         InfluxDbPublisher.DescriptorImpl descriptorMock = Mockito.mock(InfluxDbPublisher.DescriptorImpl.class);
         Jenkins jenkinsMock = Mockito.mock(Jenkins.class);
         Mockito.when(descriptorMock.getTargets()).thenReturn(Collections.emptyList());
         Mockito.when(jenkinsMock.getDescriptorByType(InfluxDbPublisher.DescriptorImpl.class)).thenReturn(descriptorMock);
 
-        try {
-            new InfluxDbPublisher("").perform(build, workspace, envVars, launcher, listener);
-        } catch (NullPointerException e) {
-            Assert.fail("NullPointerException raised");
-        }
+        assertThrows("Target was null!", RuntimeException.class, () -> new InfluxDbPublisher("").perform(build, workspace, envVars, launcher, listener));
     }
 
     @Test

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/AgentPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/AgentPointGeneratorTest.java
@@ -1,0 +1,130 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.influxdb.client.write.Point;
+
+import hudson.model.AbstractBuild;
+import hudson.model.HealthReport;
+import hudson.model.Job;
+import hudson.model.Node;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.labels.LabelAtom;
+import jenkins.model.Jenkins;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+
+/**
+ * @author Mathieu Delrocq
+ */
+public class AgentPointGeneratorTest {
+
+    private static final String CUSTOM_PREFIX = "test_prefix";
+    private static final String JOB_NAME = "job_name";
+
+    private static final String NODE_NAME = "node_name";
+    private static final String NODE_LABEL = "node_label";
+
+    private Run<?, ?> abstractBuild;
+    private WorkflowRun pipelineBuild;
+    private Node node;
+    private FlowNode flowNode1;
+    private FlowNode flowNode2;
+    private List<FlowNode> flowNodeList;
+    private FlowExecutionOwner flowExecutionOwner;
+    private FlowExecution flowExecution;
+    private WorkspaceAction workspaceAction1;
+    private WorkspaceAction workspaceAction2;
+    private TaskListener listener;
+    private long currTime;
+    private ProjectNameRenderer measurementRenderer;
+
+    @Before
+    public void before() throws Exception {
+        // Global Mocks
+        listener = Mockito.mock(TaskListener.class);
+        currTime = System.currentTimeMillis();
+        measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
+        Job<?, ?> job = Mockito.mock(Job.class);
+        Mockito.when(job.getName()).thenReturn(JOB_NAME);
+        Mockito.when(job.getRelativeNameFrom(Mockito.nullable(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
+        Mockito.when(job.getBuildHealth()).thenReturn(new HealthReport());
+
+        // Mocks for AbstractBuild
+        abstractBuild = Mockito.mock(AbstractBuild.class);
+        Mockito.doReturn(job).when(abstractBuild).getParent();
+        node = Mockito.mock(Node.class);
+        Mockito.when(((AbstractBuild<?, ?>) abstractBuild).getBuiltOn()).thenReturn(node);
+        Mockito.when(node.getDisplayName()).thenReturn(NODE_NAME);
+        Mockito.when(node.getLabelString()).thenReturn(NODE_LABEL);
+
+        // Mock for Pipeline
+        pipelineBuild = Mockito.mock(WorkflowRun.class);
+        Mockito.doReturn(job).when(pipelineBuild).getParent();
+        flowNode1 = Mockito.mock(FlowNode.class);
+        flowNode2 = Mockito.mock(FlowNode.class);
+        flowExecutionOwner = Mockito.mock(FlowExecutionOwner.class);
+        flowExecution = Mockito.mock(FlowExecution.class);
+        flowNodeList = new ArrayList<FlowNode>();
+        flowNodeList.add(flowNode1);
+        flowNodeList.add(flowNode2);
+        workspaceAction1 = Mockito.mock(WorkspaceAction.class);
+        workspaceAction2 = Mockito.mock(WorkspaceAction.class);
+        Set<LabelAtom> labels = new HashSet<LabelAtom>();
+        LabelAtom label = new LabelAtom(NODE_LABEL);
+        labels.add(label);
+        Mockito.when(pipelineBuild.asFlowExecutionOwner()).thenReturn(flowExecutionOwner);
+        Mockito.when(flowExecutionOwner.getOrNull()).thenReturn(flowExecution);
+        Mockito.when(flowExecution.getCurrentHeads()).thenReturn(flowNodeList);
+        Mockito.when(flowNode1.getAction(WorkspaceAction.class)).thenReturn(workspaceAction1);
+        Mockito.when(flowNode2.getAction(WorkspaceAction.class)).thenReturn(workspaceAction2);
+        Mockito.when(workspaceAction1.getNode()).thenReturn(NODE_NAME);
+        Mockito.when(workspaceAction1.getLabels()).thenReturn(labels);
+        Mockito.when(workspaceAction2.getNode()).thenReturn(NODE_NAME + "2");
+        Mockito.when(workspaceAction2.getLabels()).thenReturn(labels);
+    }
+
+    @Test
+    public void pipeline_agent_present() {
+        AgentPointGenerator gen = new AgentPointGenerator(pipelineBuild, listener, measurementRenderer, currTime,
+                StringUtils.EMPTY, CUSTOM_PREFIX);
+        assertTrue(gen.hasReport());
+        Point[] points = gen.generate();
+        assertTrue(points != null && points.length != 0);
+        assertTrue(points[0].hasFields());
+        String lineProtocol1 = points[0].toLineProtocol();
+        String lineProtocol2 = points[1].toLineProtocol();
+        assertTrue(lineProtocol1.contains("agent_name=\"node_name2\""));
+        assertTrue(lineProtocol1.contains("agent_label=\"node_label\""));
+        assertTrue(lineProtocol2.contains("agent_name=\"node_name\""));
+        assertTrue(lineProtocol2.contains("agent_label=\"node_label\""));
+    }
+
+    @Test
+    public void abstractbuild_agent_present() {
+        AgentPointGenerator gen = new AgentPointGenerator(abstractBuild, listener, measurementRenderer, currTime,
+                StringUtils.EMPTY, CUSTOM_PREFIX);
+        assertTrue(gen.hasReport());
+        Point[] points = gen.generate();
+        assertTrue(points != null && points.length != 0);
+        assertTrue(points[0].hasFields());
+        String lineProtocol = points[0].toLineProtocol();
+        assertTrue(lineProtocol.contains("agent_name=\"node_name\""));
+        assertTrue(lineProtocol.contains("agent_label=\"node_label\""));
+    }
+}

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -91,7 +91,7 @@ public class CustomDataMapPointGeneratorTest {
             lineProtocol1 = pointsToWrite[1].toLineProtocol();
             lineProtocol2 = pointsToWrite[0].toLineProtocol();
         }
-        assertTrue(lineProtocol1.startsWith("series1,build_result=SUCCESS,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test1=11i,test2=22i"));
-        assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test3=33i,test4=44i"));
+        assertTrue(lineProtocol1.startsWith("series1,build_result=SUCCESS,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test1=11i,test2=22i"));
+        assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master build_number=11i,project_name=\"test_prefix_master\",project_path=\"folder/master\",test3=33i,test4=44i"));
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataPointGeneratorTest.java
@@ -69,8 +69,8 @@ public class CustomDataPointGeneratorTest {
         Point[] pointsToWrite = cdGen.generate();
 
         String lineProtocol = pointsToWrite[0].toLineProtocol();
-        assertTrue(lineProtocol.startsWith("jenkins_custom_data,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,tag1=myTag build_number=11i,build_time="));
-        assertTrue(lineProtocol.contains("project_name=\"test_prefix_master\",project_path=\"folder/master\",test1=11i,test2=22i"));
+        assertTrue(lineProtocol.startsWith("jenkins_custom_data,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master,tag1=myTag build_number=11i,build_time="));
+        assertTrue(lineProtocol.contains("jenkins_custom_data,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master,tag1=myTag build_number=11i"));
     }
 
     @Test

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/GitPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/GitPointGeneratorTest.java
@@ -1,0 +1,110 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.influxdb.client.write.Point;
+
+import hudson.model.HealthReport;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.Revision;
+import hudson.plugins.git.util.BuildData;
+import jenkins.model.Jenkins;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+
+/**
+ * @author Mathieu Delrocq
+ */
+public class GitPointGeneratorTest {
+
+    private static final String CUSTOM_PREFIX = "test_prefix";
+    private static final String JOB_NAME = "job_name";
+    private static final String GIT_REPOSITORY = "repository";
+    private static final String GIT_REFERENCE = "reference";
+    private static final String GIT_REVISION = "revision";
+
+    private Run<?, ?> build;
+    private List<BuildData> gitActions;
+    private BuildData gitAction1;
+    private BuildData gitAction2;
+    private TaskListener listener;
+    private long currTime;
+    private ProjectNameRenderer measurementRenderer;
+    private Revision revision1;
+    private Revision revision2;
+    private Branch branch1;
+    private Branch branch2;
+
+    @Before
+    public void before() throws Exception {
+        // Global Mocks
+        listener = Mockito.mock(TaskListener.class);
+        currTime = System.currentTimeMillis();
+        measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
+        Job<?, ?> job = Mockito.mock(Job.class);
+        Mockito.when(job.getName()).thenReturn(JOB_NAME);
+        Mockito.when(job.getRelativeNameFrom(Mockito.nullable(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
+        Mockito.when(job.getBuildHealth()).thenReturn(new HealthReport());
+
+        build = Mockito.mock(Run.class);
+        Mockito.doReturn(job).when(build).getParent();
+        gitAction1 = Mockito.mock(BuildData.class);
+        gitAction2 = Mockito.mock(BuildData.class);
+        gitActions = new ArrayList<>();
+        gitActions.add(gitAction1);
+        gitActions.add(gitAction2);
+        branch1 = Mockito.mock(Branch.class);
+        branch2 = Mockito.mock(Branch.class);
+        revision1 = Mockito.mock(Revision.class);
+        revision2 = Mockito.mock(Revision.class);
+        Mockito.when(build.getActions(BuildData.class)).thenReturn(gitActions);
+        Mockito.when(gitAction1.getLastBuiltRevision()).thenReturn(revision1);
+        Mockito.when(gitAction2.getLastBuiltRevision()).thenReturn(revision2);
+        List<Branch> branches1 = Arrays.asList(branch1);
+        List<Branch> branches2 = Arrays.asList(branch2);
+        Mockito.when(revision1.getBranches()).thenReturn(branches1);
+        Mockito.when(revision2.getBranches()).thenReturn(branches2);
+        Mockito.when(branch1.getName()).thenReturn(GIT_REFERENCE);
+        Mockito.when(branch2.getName()).thenReturn(GIT_REFERENCE + "2");
+        Mockito.when(revision1.getSha1String()).thenReturn(GIT_REVISION);
+        Mockito.when(revision2.getSha1String()).thenReturn(GIT_REVISION + "2");
+        Set<String> remoteUrls1 = new HashSet<>();
+        remoteUrls1.add(GIT_REPOSITORY);
+        Set<String> remoteUrls2 = new HashSet<>();
+        remoteUrls2.add(GIT_REPOSITORY + "2");
+        Mockito.when(gitAction1.getRemoteUrls()).thenReturn(remoteUrls1);
+        Mockito.when(gitAction2.getRemoteUrls()).thenReturn(remoteUrls2);
+    }
+
+    @Test
+    public void test_with_datas() {
+        GitPointGenerator gen = new GitPointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY,
+                CUSTOM_PREFIX);
+        assertTrue(gen.hasReport());
+        Point[] points = gen.generate();
+        assertTrue(points != null && points.length != 0);
+        assertTrue(points[0].hasFields());
+        String lineProtocol = points[0].toLineProtocol();
+        assertTrue(lineProtocol.contains("git_repository=\"repository\""));
+        assertTrue(lineProtocol.contains("git_revision=\"revision\""));
+        assertTrue(lineProtocol.contains("git_reference=\"reference\""));
+        String lineProtocol2 = points[1].toLineProtocol();
+        assertTrue(lineProtocol2.contains("git_repository=\"repository2\""));
+        assertTrue(lineProtocol2.contains("git_revision=\"revision2\""));
+        assertTrue(lineProtocol2.contains("git_reference=\"reference2\""));
+    }
+
+}

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/MetricsPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/MetricsPointGeneratorTest.java
@@ -1,0 +1,72 @@
+package jenkinsci.plugins.influxdb.generators;
+
+import com.influxdb.client.write.Point;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.metrics.impl.TimeInQueueAction;
+import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertTrue;
+
+public class MetricsPointGeneratorTest {
+
+    private static final String JOB_NAME = "master";
+    private static final int BUILD_NUMBER = 11;
+    private static final String CUSTOM_PREFIX = "test_prefix";
+
+    private Run build;
+    private TaskListener listener;
+    private ProjectNameRenderer measurementRenderer;
+    private TimeInQueueAction timeInQueueAction;
+
+    private long currTime;
+
+    @Before
+    public void before() {
+        build = Mockito.mock(Run.class);
+        Job job = Mockito.mock(Job.class);
+        listener = Mockito.mock(TaskListener.class);
+        measurementRenderer = new ProjectNameRenderer(CUSTOM_PREFIX, null);
+        timeInQueueAction = Mockito.mock(TimeInQueueAction.class);
+
+        Mockito.when(build.getNumber()).thenReturn(BUILD_NUMBER);
+        Mockito.when(build.getParent()).thenReturn(job);
+        Mockito.when(job.getName()).thenReturn(JOB_NAME);
+        Mockito.when(build.getAction(TimeInQueueAction.class)).thenReturn(timeInQueueAction);
+
+        currTime = System.currentTimeMillis();
+    }
+
+    @Test
+    public void measurement_successfully_generated() {
+        Mockito.when(timeInQueueAction.getBlockedDurationMillis()).thenReturn((long)10);
+        Mockito.when(timeInQueueAction.getBuildableDurationMillis()).thenReturn((long)20);
+        Mockito.when(timeInQueueAction.getBuildingDurationMillis()).thenReturn((long)30);
+        Mockito.when(timeInQueueAction.getExecutingTimeMillis()).thenReturn((long)40);
+        Mockito.when(timeInQueueAction.getExecutorUtilization()).thenReturn(0.5);
+        Mockito.when(timeInQueueAction.getQueuingDurationMillis()).thenReturn((long)50);
+        Mockito.when(timeInQueueAction.getSubTaskCount()).thenReturn(2);
+        Mockito.when(timeInQueueAction.getTotalDurationMillis()).thenReturn((long)60);
+        Mockito.when(timeInQueueAction.getWaitingDurationMillis()).thenReturn((long)70);
+
+        MetricsPointGenerator generator = new MetricsPointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX);
+        Point[] points = generator.generate();
+        String lineProtocol = points[0].toLineProtocol();
+
+        assertTrue(lineProtocol.contains("blocked_time=10"));
+        assertTrue(lineProtocol.contains("buildable_time=20"));
+        assertTrue(lineProtocol.contains("building_time=30"));
+        assertTrue(lineProtocol.contains("executing_time=40"));
+        assertTrue(lineProtocol.contains("executor_utilization=0.5"));
+        assertTrue(lineProtocol.contains("queue_time=50"));
+        assertTrue(lineProtocol.contains("subtask_count=2"));
+        assertTrue(lineProtocol.contains("total_duration=60"));
+        assertTrue(lineProtocol.contains("waiting_time=70"));
+    }
+
+}

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/MetricsPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/MetricsPointGeneratorTest.java
@@ -5,6 +5,7 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.metrics.impl.TimeInQueueAction;
+import jenkins.model.Jenkins;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
@@ -38,6 +39,7 @@ public class MetricsPointGeneratorTest {
         Mockito.when(build.getParent()).thenReturn(job);
         Mockito.when(job.getName()).thenReturn(JOB_NAME);
         Mockito.when(build.getAction(TimeInQueueAction.class)).thenReturn(timeInQueueAction);
+        Mockito.when(job.getRelativeNameFrom(Mockito.nullable(Jenkins.class))).thenReturn("folder/" + JOB_NAME);
 
         currTime = System.currentTimeMillis();
     }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/PerfPublisherPointGeneratorTest.java
@@ -95,9 +95,9 @@ public class PerfPublisherPointGeneratorTest {
         PerfPublisherPointGenerator generator = new PerfPublisherPointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX);
         Point[] points = generator.generate();
 
-        assertTrue(points[0].toLineProtocol().startsWith("perfpublisher_summary,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master build_number=11i,number_of_executed_tests=1i"));
-        assertTrue(points[1].toLineProtocol().startsWith("perfpublisher_metric,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master average=50.0,best=50.0,build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",worst=50.0"));
-        assertTrue(points[2].toLineProtocol().startsWith("perfpublisher_test,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,test_name=test.txt build_number=11i,executed=true,project_name=\"test_prefix_master\",project_path=\"folder/master\",successful=false,test_name=\"test.txt\""));
-        assertTrue(points[3].toLineProtocol().startsWith("perfpublisher_test_metric,prefix=test_prefix,project_name=test_prefix_master,project_path=folder/master,test_name=test.txt build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",relevant=true,test_name=\"test.txt\",unit=\"ms\",value=50.0"));
+        assertTrue(points[0].toLineProtocol().startsWith("perfpublisher_summary,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master build_number=11i,number_of_executed_tests=1i"));
+        assertTrue(points[1].toLineProtocol().startsWith("perfpublisher_metric,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master average=50.0,best=50.0,build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",worst=50.0"));
+        assertTrue(points[2].toLineProtocol().startsWith("perfpublisher_test,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master,test_name=test.txt build_number=11i,executed=true,project_name=\"test_prefix_master\",project_path=\"folder/master\",successful=false,test_name=\"test.txt\""));
+        assertTrue(points[3].toLineProtocol().startsWith("perfpublisher_test_metric,prefix=test_prefix,project_name=test_prefix_master,project_namespace=folder,project_path=folder/master,test_name=test.txt build_number=11i,metric_name=\"metric1\",project_name=\"test_prefix_master\",project_path=\"folder/master\",relevant=true,test_name=\"test.txt\",unit=\"ms\",value=50.0"));
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
@@ -202,10 +202,10 @@ public class SonarQubePointGeneratorTest {
         try {
             
             String parentCustomDir = customReportPath[customReportPath.length - 1];
-            Path customReportPathPatttern = Paths.get(parentCustomDir, 
+            Path customReportPathPattern = Paths.get(parentCustomDir,
                                                     customReportName);
                                                     
-            Mockito.doReturn(customReportPathPatttern.toString())
+            Mockito.doReturn(customReportPathPattern.toString())
                 .when(envVars)
                 .get(any(String.class));
 

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/SonarQubePointGeneratorTest.java
@@ -1,16 +1,25 @@
 package jenkinsci.plugins.influxdb.generators;
 
+import hudson.EnvVars;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkinsci.plugins.influxdb.renderer.ProjectNameRenderer;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.ClassRule;
 import org.mockito.Mockito;
+import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
+
+import java.util.List;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.Files;
 
 public class SonarQubePointGeneratorTest {
 
@@ -18,12 +27,57 @@ public class SonarQubePointGeneratorTest {
     private static final int BUILD_NUMBER = 11;
     private static final String CUSTOM_PREFIX = "test_prefix";
 
+            
     private Run build;
     private TaskListener listener;
     private ProjectNameRenderer measurementRenderer;
     private String sonarUrl = "http://sonar.dashboard.com";
 
     private long currTime;
+
+    // temp file system settings for testing find report file 
+    @ClassRule
+    public static TemporaryFolder folder = new TemporaryFolder();
+    
+    private static final String[] mvnReportPath = {"maven-basic", "target", "sonar"};
+    private static final String defaultReportName = "report-task.txt";
+    private static final String[] customReportPath = {"custom", "report", "path"};
+    private static final String customReportName  = "custom-report.txt";
+
+    @BeforeClass
+    public static void beforeClass() {
+        
+        // create a dummy file system with the scanner report file
+        // temp-dir/
+        //  - maven-basic/target/sonar/report-task.txt
+        //  - custom/report/path/custom-report.txt
+        //  - temp{1..5}/
+        //      - temfiles...
+        String wsRoot = folder.getRoot().toString();
+        Path wsSonarDir = Paths.get(wsRoot, mvnReportPath);
+        Path sonarReport = wsSonarDir.resolve(defaultReportName); 
+        Path customSonarReportDir = Paths.get(wsRoot, customReportPath);
+        Path sonarCustomReport = customSonarReportDir.resolve(customReportName); 
+
+        try {
+            Files.createDirectories(wsSonarDir);  
+            Files.createFile(sonarReport);
+            Files.createDirectories(customSonarReportDir); 
+            Files.createFile(sonarCustomReport);
+            
+            // create temp dirs and files
+            for (int i = 0; i < 5; i++) {
+                String tmpDirName = "temp" + i;
+                Path tmpPath = Paths.get(wsRoot, tmpDirName);
+                Files.createDirectories(tmpPath);
+                for (int j = 0; j < 10; j++) {
+                    Files.createTempFile(tmpPath, null, ".class");
+                }
+            }
+        }catch(Exception e) {
+            System.err.println("[InfluxDB Plugin Test] ERROR: Failed to create a temp file system - " + e.getMessage());
+        }
+    }
 
     @Before
     public void before() {
@@ -40,29 +94,14 @@ public class SonarQubePointGeneratorTest {
     }
 
     @Test
-    public void getSonarProjectNameFromNewSonarQube() throws Exception {
-        String name = "org.namespace:feature%2Fmy-sub-project";
-        String url = sonarUrl + "/dashboard?id=" + name;
-        SonarQubePointGenerator gen = new SonarQubePointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX);
-        assertEquals(gen.getSonarProjectName(url), name);
-    }
-
-    @Test
-    public void getSonarProjectName() throws Exception {
-        String name = "org.namespace:feature%2Fmy-sub-project";
-        String url = sonarUrl + "/dashboard/index/" + name;
-        SonarQubePointGenerator gen = new SonarQubePointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX);
-        assertEquals(gen.getSonarProjectName(url), name);
-    }
-
-    @Test
     public void getSonarProjectMetric() throws Exception {
+        EnvVars envVars = new EnvVars();
         String name = "org.namespace:feature%2Fmy-sub-project";
         String metric_key = "code_smells";
         String metric_value = "59";
         String responseJson = "{\"component\":{\"id\":\"AWZS_ynA7tIj5HosrIjz\",\"key\":\"" + name + "\",\"name\":\"Fake Statistics\",\"qualifier\":\"TRK\",\"measures\":[{\"metric\":\"" + metric_key + "\",\"value\":\"" + metric_value +"\",\"bestValue\":false}]}}";
         String url = sonarUrl + "/api/measures/component?componentKey=" + name + "&metricKeys=" + metric_key;
-        SonarQubePointGenerator gen = Mockito.spy(new SonarQubePointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX));
+        SonarQubePointGenerator gen = Mockito.spy(new SonarQubePointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX, envVars));
 
         Mockito.doReturn(responseJson).when(gen).getResult(any(String.class));
         assertEquals(java.util.Optional.of(gen.getSonarMetric(url, metric_key)), java.util.Optional.of(Float.parseFloat(metric_value)));
@@ -70,13 +109,111 @@ public class SonarQubePointGeneratorTest {
 
     @Test
     public void getSonarProjectMetric_NoMetric() throws Exception {
+        EnvVars envVars = new EnvVars();
         String name = "org.namespace:feature%2Fmy-sub-project";
         String metric_key = "branch_coverage";
         String responseJson = "{\"component\":{\"id\":\"AWZS_ynA7tIj5HosrIjz\",\"key\":\"" + name + "\",\"name\":\"Fake Statistics\",\"qualifier\":\"TRK\",\"measures\":[]}}";
         String url = sonarUrl + "/api/measures/component?componentKey=" + name + "&metricKeys=" + metric_key;
-        SonarQubePointGenerator gen = Mockito.spy(new SonarQubePointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX));
+        SonarQubePointGenerator gen = Mockito.spy(new SonarQubePointGenerator(build, listener, measurementRenderer, currTime, StringUtils.EMPTY, CUSTOM_PREFIX, envVars));
 
         Mockito.doReturn(responseJson).when(gen).getResult(any(String.class));
         assertNull(gen.getSonarMetric(url, metric_key));
+    }
+
+   
+    @Test
+    public void getSonarDefaultReportFilePath() {
+        // Find default sonar report-task.txt file 
+        EnvVars envVars = new EnvVars();
+
+        SonarQubePointGenerator gen = Mockito.spy(
+                                    new SonarQubePointGenerator(build, 
+                                                                listener, 
+                                                                measurementRenderer, 
+                                                                currTime, 
+                                                                StringUtils.EMPTY, 
+                                                                CUSTOM_PREFIX, 
+                                                                envVars));
+
+        String wsRoot = folder.getRoot().toString();
+        Path wsSonarDir = Paths.get(wsRoot, mvnReportPath);
+        Path sonarReport = wsSonarDir.resolve(defaultReportName); 
+
+        try {
+            List<Path> result = gen.findReportByFileName(wsRoot);    
+            assertEquals(1, result.size());
+
+            Files.deleteIfExists(sonarReport);
+            result = gen.findReportByFileName(wsRoot);
+            assertEquals(0, result.size());
+        } catch(Exception e){
+            System.err.println("[InfluxDB Plugin Test] ERROR: Failed to find default report file - " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void getSonarCustomReportFileName() {
+        // Find a custom report file defined by SONARQUBE_BUILD_REPORT_NAME env var 
+        // Example: custom-report.txt
+        EnvVars envVars = Mockito.spy(new EnvVars());
+
+        SonarQubePointGenerator gen = Mockito.spy(
+                                    new SonarQubePointGenerator(build, 
+                                                                listener, 
+                                                                measurementRenderer, 
+                                                                currTime, 
+                                                                StringUtils.EMPTY, 
+                                                                CUSTOM_PREFIX, 
+                                                                envVars));
+
+        String wsRoot = folder.getRoot().toString();
+
+        try {
+            
+            Mockito.doReturn(customReportName)
+                .when(envVars)
+                .get(any(String.class));
+
+            List<Path> result = gen.findReportByFileName(wsRoot);    
+            assertEquals(1, result.size());
+
+        } catch(Exception e){
+            System.err.println("[InfluxDB Plugin Test] ERROR: Failed to find custom report file - " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void getSonarCustomReportFilePath() {
+        // Find a custom report path defined by SONARQUBE_BUILD_REPORT_NAME env var
+        // Example: path/custom-report.txt
+        EnvVars envVars = Mockito.spy(new EnvVars());
+
+        SonarQubePointGenerator gen = Mockito.spy(
+                                    new SonarQubePointGenerator(build, 
+                                                                listener, 
+                                                                measurementRenderer, 
+                                                                currTime, 
+                                                                StringUtils.EMPTY, 
+                                                                CUSTOM_PREFIX, 
+                                                                envVars));
+
+        String wsRoot = folder.getRoot().toString();
+
+        try {
+            
+            String parentCustomDir = customReportPath[customReportPath.length - 1];
+            Path customReportPathPatttern = Paths.get(parentCustomDir, 
+                                                    customReportName);
+                                                    
+            Mockito.doReturn(customReportPathPatttern.toString())
+                .when(envVars)
+                .get(any(String.class));
+
+            List<Path>  result = gen.findReportByFileName(wsRoot);    
+            assertEquals(1, result.size());
+
+        } catch(Exception e){
+            System.err.println("[InfluxDB Plugin Test] ERROR: Failed to find custom report file path - " + e.getMessage());
+        }
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityJsonSummaryFileTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/serenity/SerenityJsonSummaryFileTest.java
@@ -1,0 +1,54 @@
+package jenkinsci.plugins.influxdb.generators.serenity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SerenityJsonSummaryFileTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testAvailableSummary() throws Exception {
+        writeToTemporaryPath("target/site/serenity/serenity-summary.json", "expected summary content");
+
+        SerenityJsonSummaryFile serenityJsonSummaryFile = new SerenityJsonSummaryFile(pathOfTemporaryFolder());
+
+        assertTrue(serenityJsonSummaryFile.exists());
+        assertEquals("expected summary content", serenityJsonSummaryFile.getContents());
+    }
+
+    @Test
+    public void testUnavailableSummary() throws Exception {
+        SerenityJsonSummaryFile serenityJsonSummaryFile = new SerenityJsonSummaryFile(pathOfTemporaryFolder());
+
+        assertFalse(serenityJsonSummaryFile.exists());
+    }
+
+    @Test
+    public void testUnavailableWorkspace() throws Exception {
+        SerenityJsonSummaryFile serenityJsonSummaryFile = new SerenityJsonSummaryFile(null);
+
+        assertFalse(serenityJsonSummaryFile.exists());
+    }
+
+    private void writeToTemporaryPath(String path, String content) throws IOException {
+        Path temporaryPath = temporaryFolder.getRoot().toPath();
+        Path summaryJson = temporaryPath.resolve(path);
+        Files.createDirectories(summaryJson.getParent());
+        Files.writeString(summaryJson, content, StandardCharsets.UTF_8);
+    }
+
+    private String pathOfTemporaryFolder() {
+        return temporaryFolder.getRoot().getAbsolutePath();
+    }
+}


### PR DESCRIPTION
Addresses [TI-1285](https://deepfield.atlassian.net/browse/TI-1285)

----

## Related PRs
N/A

----
## Summary
Updates development branch to influxdb-3.6 (from forked repo) including our (TI's) changes to the plugin.

----
## Additional Scope
N/A

----
## Testing
This was tested on `test-jenkins` and verified checking the system log in addition to grafana.

See results from fi tests ran:
![upload_from_job](https://github.com/deepfield/influxdb-plugin/assets/83968990/0d7a2c49-568c-475a-a9f6-8cc94e6c8731)

Influxdb jenkins syslog:
![influxdb_syslog](https://github.com/deepfield/influxdb-plugin/assets/83968990/50113f79-6738-4309-b363-9810d62df186)

Grafana results from a [previously unavailable before this fix] measure:
![summed_time_in_queue_testjenkins_grafana](https://github.com/deepfield/influxdb-plugin/assets/83968990/b54286f4-73bc-45cd-aaf9-4b288f79f894)

A single run of Bird_FI_Tests evaluated with a 30 min time window:
![summed_time_30min](https://github.com/deepfield/influxdb-plugin/assets/83968990/aa8e0821-f454-45b9-aaf4-b5d908d106ea)

----
## Extra Context
N/A

[TI-1285]: https://deepfield.atlassian.net/browse/TI-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ